### PR TITLE
Add support for FIPS_MODE_ENABLED flag

### DIFF
--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -32,7 +32,7 @@ The **Opt-In Annotation** column contains the annotation that must be added to a
 |--|--|--|--|--|
 | Container Registry Rewrite | Replace container registry hosts with another host (e.g., for private container registries).| Rewrite container registry host in `image` field.| Rewrite registry hosts in `.spec.containers[*].image` | `rt-cfg.kyma-project.io/alter-img-registry: "true"`|
 | Image Pull Secret Injection | The webhook ensures that the Secret resource exists in the namespace and adds a pull-secret entry to the manifest if the registry requires user credentials.| Add Secret reference to the `imagePullSecrets` field. | Append array `.spec.imagePullSecrets[]` with entry `registry-credentials` | `rt-cfg.kyma-project.io/add-img-pull-secret: "true"`|
-| FIPS Mode Enablement| The webhook sets an environment variable in the Pod to enable FIPS mode. | Add environment variable `KYMA_FIPS_MODE_ENABLED`. | Append key-value array `.spec.containers[*].env[]` with `KYMA_FIPS_MODE_ENABLED=true`   | `rt-cfg.kyma-project.io/set-fips-mode: "true"`     |
+| FIPS Mode Enablement| The webhook sets environment variables in the Pod to enable FIPS mode. | Add environment variables `KYMA_FIPS_MODE_ENABLED` and `FIPS_MODE_ENABLED`. | Append key-value array `.spec.containers[*].env[]` with `KYMA_FIPS_MODE_ENABLED=true` and `FIPS_MODE_ENABLED=true`   | `rt-cfg.kyma-project.io/set-fips-mode: "true"`     |
 | Mount Cluster Trust Bundle Volume | Mount a certificate (stored as `ClusterTrustBundle`) as a projected volume into the container under the path `/etc/ssl/certs` (includes init-containers).| Mount a projected `volume` from `ClusterTrustBundle` to each container in the Pod under path `/etc/ssl/certs`. | 1. Add projected volume `rt-bootstrapper-certs` to `.spec.volumes[]`<br/>2. Mount this volume into each container under the mount path `/etc/ssl/certs` by extending the array `.spec.containers[*].volumeMounts` | `rt-cfg.kyma-project.io/add-cluster-trust-bundle: "true"` |
 
 > [!NOTE]
@@ -93,9 +93,11 @@ metadata:
 spec:
   containers:
   - env:
-    - name: KYMA_FIPS_MODE_ENABLED.                            # FIPS mode enabled
+    - name: KYMA_FIPS_MODE_ENABLED                             # FIPS mode enabled
       value: "true"
-    image: ghcr.io/kyma-project/rt-bootstrapper/pause:e2e.     # Registry host rewritten
+    - name: FIPS_MODE_ENABLED                                  # FIPS mode enabled (legacy)
+      value: "true"
+    image: ghcr.io/kyma-project/rt-bootstrapper/pause:e2e      # Registry host rewritten
     name: pause
     volumeMounts:                                              # ClusterTrustBundle as volume mounted
     - mountPath: /etc/ssl/certs

--- a/internal/webhook/v1/pod_defaulter_fips_mode.go
+++ b/internal/webhook/v1/pod_defaulter_fips_mode.go
@@ -13,9 +13,13 @@ var (
 		apiv1.AnnotationSetFipsMode: "true",
 	}
 
-	envVarKymaFipsModeEnabled = corev1.EnvVar{
-		Name:  apiv1.EnvKymaFipsModeEnabled,
-		Value: "true",
+	// fipsModeEnvVarNames contains all environment variable names that should be set
+	// when FIPS mode is enabled. Both are set for backward compatibility:
+	// - KYMA_FIPS_MODE_ENABLED: the canonical Kyma environment variable
+	// - FIPS_MODE_ENABLED: legacy variable used by some modules
+	fipsModeEnvVarNames = []string{
+		apiv1.EnvKymaFipsModeEnabled,
+		apiv1.EnvFipsModeEnabled,
 	}
 )
 
@@ -23,31 +27,11 @@ func BuildDefaulterFipsMode() PodDefaulter {
 	handleContainers := func(cs []corev1.Container) bool {
 		var modified bool
 		for i, c := range cs {
-			index := slices.IndexFunc(c.Env, func(v corev1.EnvVar) bool {
-				return v.Name == apiv1.EnvKymaFipsModeEnabled
-			})
-			// env variable not found
-			if index == -1 {
-				cs[i].Env = append(c.Env, envVarKymaFipsModeEnabled)
-				modified = true
-				slog.Debug("env variable added",
-					"name", apiv1.EnvKymaFipsModeEnabled)
-				continue
+			for _, envName := range fipsModeEnvVarNames {
+				if setFipsModeEnvVar(&cs[i], c.Env, envName) {
+					modified = true
+				}
 			}
-			// env variable already exists and has the same value
-			if cs[i].Env[index].Value == "true" {
-				slog.Debug("env variable already exists",
-					"name", apiv1.EnvKymaFipsModeEnabled,
-				)
-				continue
-			}
-			// env variable already exists but has different value
-			slog.Debug("replacing env variable",
-				"name", apiv1.EnvKymaFipsModeEnabled,
-				"prev", c.Env[i].Value,
-			)
-			cs[i].Env[index] = envVarKymaFipsModeEnabled
-			modified = true
 		}
 		return modified
 	}
@@ -68,4 +52,38 @@ func BuildDefaulterFipsMode() PodDefaulter {
 	return defaultPod(setFipsMode, updateOpts{
 		activeAnnotations: annotationSetFipsMode,
 	})
+}
+
+// setFipsModeEnvVar ensures the given environment variable is set to "true" in the container.
+// Returns true if the container was modified.
+func setFipsModeEnvVar(container *corev1.Container, currentEnv []corev1.EnvVar, envName string) bool {
+	index := slices.IndexFunc(currentEnv, func(v corev1.EnvVar) bool {
+		return v.Name == envName
+	})
+
+	envVar := corev1.EnvVar{
+		Name:  envName,
+		Value: "true",
+	}
+
+	// env variable not found - add it
+	if index == -1 {
+		container.Env = append(container.Env, envVar)
+		slog.Debug("env variable added", "name", envName)
+		return true
+	}
+
+	// env variable already exists and has the same value
+	if container.Env[index].Value == "true" {
+		slog.Debug("env variable already exists", "name", envName)
+		return false
+	}
+
+	// env variable already exists but has different value - replace it
+	slog.Debug("replacing env variable",
+		"name", envName,
+		"prev", container.Env[index].Value,
+	)
+	container.Env[index] = envVar
+	return true
 }

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -18,6 +18,7 @@ const (
 	AnnotationModified              = "rt-bootstrapper.kyma-project.io/modified"
 	FiledManager                    = "rt-bootstrapper"
 	EnvKymaFipsModeEnabled          = "KYMA_FIPS_MODE_ENABLED"
+	EnvFipsModeEnabled              = "FIPS_MODE_ENABLED"
 	ConfigMapKey                    = "rt-bootstrapper-config.json"
 )
 


### PR DESCRIPTION
## Description

This PR adds support for setting both `KYMA_FIPS_MODE_ENABLED` and `FIPS_MODE_ENABLED` environment variables when FIPS mode is enabled via the Runtime Bootstrapper webhook.

### Motivation

Some Kyma modules already use the `FIPS_MODE_ENABLED` environment variable to detect FIPS mode enablement. When Runtime Bootstrapper was introduced, it used a new canonical environment variable `KYMA_FIPS_MODE_ENABLED`. This creates a compatibility issue where modules checking for `FIPS_MODE_ENABLED` won't detect FIPS mode in Runtime Bootstrapper landscapes.

By setting both environment variables, we ensure:
- **Backward compatibility**: Existing modules that check for `FIPS_MODE_ENABLED` continue to work without code changes
- **Forward compatibility**: New modules can use the canonical `KYMA_FIPS_MODE_ENABLED` variable
- **Zero migration effort**: Module teams don't need to update their code

### Changes

1. **`pkg/api/v1/types.go`**: Added new constant `EnvFipsModeEnabled = "FIPS_MODE_ENABLED"`

2. **`internal/webhook/v1/pod_defaulter_fips_mode.go`**: Refactored to use a slice of environment variable names (`fipsModeEnvVarNames`) containing both variables. Extracted a reusable `setFipsModeEnvVar` helper function.

3. **`docs/contributor/README.md`**: Updated documentation and example to reflect that both environment variables are now set.

### Example

When a pod has the `rt-cfg.kyma-project.io/set-fips-mode: "true"` annotation, it will receive:

```yaml
spec:
  containers:
  - env:
    - name: KYMA_FIPS_MODE_ENABLED
      value: "true"
    - name: FIPS_MODE_ENABLED
      value: "true"
```

### Testing

- [x] Code compiles successfully
- [x] `go vet` passes
- [x] Unit tests pass

### Related Issue

Closes #95 