### PR TITLE
Bump Go version to 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.26.0-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine3.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/rt-bootstrapper
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary
- Update Go version from 1.26.0 to 1.26.2 in go.mod
- Update Dockerfile to use golang:1.26.2-alpine3.23

## Changes
- go.mod: go 1.26.0 → 1.26.2
- Dockerfile: golang:1.26.0-alpine3.23 → golang:1.26.2-alpine3.23