### PR TITLE
Add end-user docs for SAP Help

### DIFF
--- a/docs/user/01-runtime-bootstrapper.md
+++ b/docs/user/01-runtime-bootstrapper.md
@@ -63,7 +63,7 @@ Each annotation enables one specific feature. To activate it, set the value to `
 | Annotation | Typical use case | NS2 (Sovereign Cloud) | CN |
 |---|---|---|---|
 | [`rt-cfg.kyma-project.io/add-cluster-trust-bundle`](#rt-cfgkyma-projectioadd-cluster-trust-bundle) | Mounts custom CA certificates required to trust SAP backend endpoints | Yes — primary feature. The CA bundle is managed by the NS2 operator team. If TLS communication fails due to missing or outdated certificates, involve the NS2 operator team to issue a replacement. Once available, the Kyma team updates the CA bundle in its configuration. Certificate changes must be handled via a service request — inform the Kyma SRE team so they can update the CA bundle on Kyma runtimes in time. | No |
-| [`rt-cfg.kyma-project.io/add-img-pull-secret`](#rt-cfgkyma-projectioadd-img-pull-secret) | Only relevant when pulling images from a private registry that requires authentication | Yes | Yes |
+| [`rt-cfg.kyma-project.io/add-img-pull-secret`](#rt-cfgkyma-projectioadd-img-pull-secret) | Only relevant when pulling images from a private registry that requires authentication | No | Yes |
 | [`rt-cfg.kyma-project.io/alter-img-registry`](#rt-cfgkyma-projectioalter-img-registry) | Only required when the container registry hostname must be rewritten to a landscape-specific mirror | No | Yes |
 | [`rt-cfg.kyma-project.io/set-fips-mode`](#rt-cfgkyma-projectioset-fips-mode) | Signals to workloads that FIPS 140-compliant cryptography should be used | Yes | No |
 | [`rt-cfg.kyma-project.io/set-landscape`](#rt-cfgkyma-projectioset-landscape) | Injects the landscape identifier for workloads that need to know which environment they run in | Yes | Yes |

--- a/docs/user/01-runtime-bootstrapper.md
+++ b/docs/user/01-runtime-bootstrapper.md
@@ -1,0 +1,185 @@
+# Runtime Bootstrapper
+
+## What Is the Runtime Bootstrapper?
+
+The Runtime Bootstrapper is a component that automatically adapts your workloads when they are deployed on SAP BTP, Kyma runtime. It runs transparently in the background and adjusts your Pods — and only your Pods — to meet the requirements of the specific landscape you are deploying into (for example, a landscape that uses a private container registry, requires FIPS-compliant workloads, or uses custom TLS certificates).
+
+You do not need to change your application code. All adjustments happen at Pod creation time, before the Pod starts running.
+
+> **Important:** The Runtime Bootstrapper only modifies **Pods**. It does not touch any other Kubernetes resources such as Deployments, Services, ConfigMaps, or Secrets.
+
+---
+
+## How to Enable It
+
+You can opt in to Runtime Bootstrapper features at two levels:
+
+### Option 1: Annotate the Namespace
+
+Add one or more feature annotations to your Namespace. All Pods created in that namespace will automatically receive the corresponding adjustments — no changes to individual workload manifests are needed.
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-namespace
+  annotations:
+    rt-cfg.kyma-project.io/alter-img-registry: "true"
+    rt-cfg.kyma-project.io/add-img-pull-secret: "true"
+```
+
+### Option 2: Annotate the Pod (or Pod Template)
+
+Add annotations directly to your Pod or to the `spec.template.metadata.annotations` section of a Deployment, StatefulSet, or similar resource. Only that specific Pod (or Pods from that template) will be adjusted.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    metadata:
+      annotations:
+        rt-cfg.kyma-project.io/alter-img-registry: "true"
+        rt-cfg.kyma-project.io/add-img-pull-secret: "true"
+    spec:
+      containers:
+        - name: my-container
+          image: my-registry.example.com/my-app:1.0.0
+```
+
+Both levels can be combined. If a feature is enabled on the namespace, all Pods in that namespace benefit from it regardless of their own annotations.
+
+> **Tip:** To enable all available features at once, use the shorthand annotation `rt-cfg.kyma-project.io/all: "true"` on either the namespace or the Pod.
+
+---
+
+## Supported Annotations
+
+Each annotation enables one specific feature. Set the value to `"true"` to activate it.
+
+---
+
+### `rt-cfg.kyma-project.io/alter-img-registry`
+
+**What it does:** Rewrites the container registry host in image references.
+
+Some landscapes require that container images are pulled from a private or landscape-specific registry instead of the original public registry. When this feature is enabled, the Runtime Bootstrapper automatically rewrites the registry hostname in the `image` field of every container and init-container in your Pod.
+
+**What changes in your Pod:**
+
+- `.spec.containers[*].image` — registry hostname is replaced
+- `.spec.initContainers[*].image` — registry hostname is replaced
+
+You do not need to know the target registry address; this is configured centrally for the landscape.
+
+---
+
+### `rt-cfg.kyma-project.io/add-img-pull-secret`
+
+**What it does:** Injects image pull credentials into your Pod.
+
+When a private container registry requires authentication, the Runtime Bootstrapper adds a reference to the landscape's image pull Secret (`registry-credentials`) to your Pod. This ensures your Pod can pull images without you having to manage registry credentials yourself.
+
+**What changes in your Pod:**
+
+- `.spec.imagePullSecrets[]` — entry `registry-credentials` is appended
+
+If the Secret reference is already present, it is not added again.
+
+---
+
+### `rt-cfg.kyma-project.io/add-cluster-trust-bundle`
+
+**What it does:** Mounts the cluster's TLS certificate bundle into your containers.
+
+Some landscapes use custom TLS certificates that are not included in the standard operating system trust store. When this feature is enabled, the Runtime Bootstrapper mounts the cluster's certificate bundle as a read-only volume into every container (including init-containers) under the path `/etc/ssl/certs`. This allows your application to trust landscape-specific HTTPS endpoints without any code changes.
+
+**What changes in your Pod:**
+
+- `.spec.volumes[]` — a projected volume named `rt-bootstrapper-certs` is added
+- `.spec.containers[*].volumeMounts` — the volume is mounted read-only at `/etc/ssl/certs`
+- `.spec.initContainers[*].volumeMounts` — same mount applied to init-containers
+
+> **Important — certificate rotation:** The mounted CA bundle can change over time. Certificates are rotated periodically for security reasons, and the file at `/etc/ssl/certs` will be updated in place without restarting your Pod. Most application runtimes load TLS trust stores once at startup and do not automatically pick up changes from the filesystem. If your application is not aware of this, it will start rejecting HTTPS connections to landscape endpoints after a rotation event.
+>
+> To handle certificate rotation, choose one of the following approaches:
+>
+> - **Watch for file changes inside your application.** Implement a file watcher that detects changes under `/etc/ssl/certs` and reloads the trust store at runtime without restarting the process. This is the most resilient approach and avoids any downtime.
+> - **Trigger an externally managed restart.** Use a controller that watches the underlying `ClusterTrustBundle` resource and automatically rolls your workload when it changes. This is conceptually similar to how [stakater/Reloader](https://github.com/stakater/Reloader) restarts Pods when a referenced ConfigMap or Secret changes. A restart ensures the new certificate is loaded, at the cost of a brief interruption.
+
+---
+
+### `rt-cfg.kyma-project.io/set-fips-mode`
+
+**What it does:** Signals FIPS 140 compliance mode to your workloads.
+
+FIPS (Federal Information Processing Standards) mode restricts cryptographic operations to approved algorithms. When this feature is enabled, the Runtime Bootstrapper sets two environment variables in every container and init-container. Your application can read these variables to activate its own FIPS-compliant code paths.
+
+**What changes in your Pod:**
+
+- `.spec.containers[*].env[]` — the following variables are added to every container:
+  - `KYMA_FIPS_MODE_ENABLED=true`
+  - `FIPS_MODE_ENABLED=true` *(legacy compatibility)*
+- `.spec.initContainers[*].env[]` — same variables added to init-containers
+
+---
+
+### `rt-cfg.kyma-project.io/set-landscape`
+
+**What it does:** Injects the landscape identifier into your containers.
+
+Some applications need to know which landscape they are running on to adjust their behavior (for example, to point to the correct backend endpoint or to display the correct region label). When this feature is enabled, the Runtime Bootstrapper injects the landscape identifier as an environment variable into every container and init-container.
+
+**What changes in your Pod:**
+
+- `.spec.containers[*].env[]` — the following variable is added:
+  - `KYMA_LANDSCAPE=<landscape-identifier>`
+- `.spec.initContainers[*].env[]` — same variable added to init-containers
+
+The actual value of the landscape identifier is provided by the landscape operator and is not configurable by the workload owner.
+
+---
+
+### `rt-cfg.kyma-project.io/all`
+
+**What it does:** Shorthand to enable all available features at once.
+
+Setting this annotation to `"true"` is equivalent to setting every feature annotation listed above. Use it when you want your namespace or Pod to receive all landscape adaptations without listing them individually.
+
+```yaml
+annotations:
+  rt-cfg.kyma-project.io/all: "true"
+```
+
+---
+
+## Confirming a Pod Was Modified
+
+After the Runtime Bootstrapper processes a Pod, it adds the following annotation to the Pod metadata:
+
+```
+rt-bootstrapper.kyma-project.io/modified: "true"
+```
+
+You can verify this with:
+
+```sh
+kubectl get pod <pod-name> -o jsonpath='{.metadata.annotations.rt-bootstrapper\.kyma-project\.io/modified}'
+```
+
+If the output is `true`, the Pod was successfully processed.
+
+---
+
+## Summary Table
+
+| Annotation | What it enables |
+|---|---|
+| `rt-cfg.kyma-project.io/alter-img-registry: "true"` | Rewrite container image registry hostnames |
+| `rt-cfg.kyma-project.io/add-img-pull-secret: "true"` | Inject image pull Secret (`registry-credentials`) |
+| `rt-cfg.kyma-project.io/add-cluster-trust-bundle: "true"` | Mount cluster TLS certificates at `/etc/ssl/certs` |
+| `rt-cfg.kyma-project.io/set-fips-mode: "true"` | Set `KYMA_FIPS_MODE_ENABLED` and `FIPS_MODE_ENABLED` env vars |
+| `rt-cfg.kyma-project.io/set-landscape: "true"` | Set `KYMA_LANDSCAPE` env var |
+| `rt-cfg.kyma-project.io/all: "true"` | Enable all of the above |

--- a/docs/user/01-runtime-bootstrapper.md
+++ b/docs/user/01-runtime-bootstrapper.md
@@ -63,6 +63,14 @@ Both levels can be combined. If a feature is enabled on a namespace, all Pods in
 
 Each annotation enables one specific feature. To activate it, set the value to `"true"`.
 
+| Annotation | Typical use case |
+|---|---|
+| [`rt-cfg.kyma-project.io/add-cluster-trust-bundle`](#rt-cfgkyma-projectioadd-cluster-trust-bundle) | Primary feature for NS2 (Sovereign Cloud) — mounts custom CA certificates required to trust SAP backend endpoints |
+| [`rt-cfg.kyma-project.io/add-img-pull-secret`](#rt-cfgkyma-projectioadd-img-pull-secret) | Only relevant when pulling images from a private registry that requires authentication |
+| [`rt-cfg.kyma-project.io/alter-img-registry`](#rt-cfgkyma-projectioalter-img-registry) | Only required when the container registry hostname must be rewritten to a landscape-specific mirror |
+| [`rt-cfg.kyma-project.io/set-fips-mode`](#rt-cfgkyma-projectioset-fips-mode) | Primarily NS2-related — signals to workloads that FIPS 140-compliant cryptography should be used |
+| [`rt-cfg.kyma-project.io/set-landscape`](#rt-cfgkyma-projectioset-landscape) | Injects the landscape identifier for workloads that need to know which environment they run in |
+
 > **Note for NS2 (Sovereign Cloud) customers:** The annotations listed below cover all configuration features supported by the Runtime Bootstrapper. In an NS2 environment, the CA bundle injection (`rt-cfg.kyma-project.io/add-cluster-trust-bundle`) is the primary feature you will need. The other features — image registry rewriting, pull secret injection, FIPS mode, and landscape identification — are only required in special cases and can be ignored for common deployments.
 
 ---

--- a/docs/user/01-runtime-bootstrapper.md
+++ b/docs/user/01-runtime-bootstrapper.md
@@ -59,6 +59,8 @@ Both levels can be combined. If a feature is enabled on the namespace, all Pods 
 
 Each annotation enables one specific feature. Set the value to `"true"` to activate it.
 
+> **Note for NS2 (Sovereign Cloud) customers:** The annotations listed below cover all configuration features supported by the Runtime Bootstrapper. In an NS2 environment, the CA bundle injection (`rt-cfg.kyma-project.io/add-cluster-trust-bundle`) is the primary feature you will need. The other features — image registry rewriting, pull secret injection, FIPS mode, and landscape identification — are only required in special cases and can be ignored for common deployments.
+
 ---
 
 ### `rt-cfg.kyma-project.io/alter-img-registry`
@@ -95,6 +97,10 @@ If the Secret reference is already present, it is not added again.
 **What it does:** Mounts the cluster's TLS certificate bundle into your containers.
 
 Some landscapes use custom TLS certificates that are not included in the standard operating system trust store. When this feature is enabled, the Runtime Bootstrapper mounts the cluster's certificate bundle as a read-only volume into every container (including init-containers) under the path `/etc/ssl/certs`. This allows your application to trust landscape-specific HTTPS endpoints without any code changes.
+
+> **CA bundle ownership (NS2):** The CA bundle is managed by the NS2 operator team, not by individual application teams. If TLS communication between your workloads and SAP backends fails due to missing or outdated certificates, you must involve the NS2 operator team to issue a suitable replacement certificate. Once a new certificate is available, the Kyma team updates the CA bundle in its configuration so it becomes accessible on Kyma runtimes.
+>
+> **Hint:** Certificate changes must be handled via a service request. Make sure to inform the Kyma SRE team about any such changes so they can update the CA bundle configuration on the Kyma runtimes in a timely manner.
 
 **What changes in your Pod:**
 

--- a/docs/user/01-runtime-bootstrapper.md
+++ b/docs/user/01-runtime-bootstrapper.md
@@ -60,19 +60,16 @@ Both levels can be combined. If a feature is enabled on a namespace, all Pods in
 
 Each annotation enables one specific feature. To activate it, set the value to `"true"`.
 
-| Annotation | Typical use case |
-|---|---|
-| [`rt-cfg.kyma-project.io/add-cluster-trust-bundle`](#rt-cfgkyma-projectioadd-cluster-trust-bundle) | Primary feature for NS2 (Sovereign Cloud) — mounts custom CA certificates required to trust SAP backend endpoints |
-| [`rt-cfg.kyma-project.io/add-img-pull-secret`](#rt-cfgkyma-projectioadd-img-pull-secret) | Only relevant when pulling images from a private registry that requires authentication |
-| [`rt-cfg.kyma-project.io/alter-img-registry`](#rt-cfgkyma-projectioalter-img-registry) | Only required when the container registry hostname must be rewritten to a landscape-specific mirror |
-| [`rt-cfg.kyma-project.io/set-fips-mode`](#rt-cfgkyma-projectioset-fips-mode) | Primarily NS2-related — signals to workloads that FIPS 140-compliant cryptography should be used |
-| [`rt-cfg.kyma-project.io/set-landscape`](#rt-cfgkyma-projectioset-landscape) | Injects the landscape identifier for workloads that need to know which environment they run in |
+| Annotation | Typical use case | NS2 (Sovereign Cloud) | CN |
+|---|---|---|---|
+| [`rt-cfg.kyma-project.io/add-cluster-trust-bundle`](#rt-cfgkyma-projectioadd-cluster-trust-bundle) | Mounts custom CA certificates required to trust SAP backend endpoints | Yes — primary feature. The CA bundle is managed by the NS2 operator team. If TLS communication fails due to missing or outdated certificates, involve the NS2 operator team to issue a replacement. Once available, the Kyma team updates the CA bundle in its configuration. Certificate changes must be handled via a service request — inform the Kyma SRE team so they can update the CA bundle on Kyma runtimes in time. | No |
+| [`rt-cfg.kyma-project.io/add-img-pull-secret`](#rt-cfgkyma-projectioadd-img-pull-secret) | Only relevant when pulling images from a private registry that requires authentication | Yes | Yes |
+| [`rt-cfg.kyma-project.io/alter-img-registry`](#rt-cfgkyma-projectioalter-img-registry) | Only required when the container registry hostname must be rewritten to a landscape-specific mirror | No | Yes |
+| [`rt-cfg.kyma-project.io/set-fips-mode`](#rt-cfgkyma-projectioset-fips-mode) | Signals to workloads that FIPS 140-compliant cryptography should be used | Yes | No |
+| [`rt-cfg.kyma-project.io/set-landscape`](#rt-cfgkyma-projectioset-landscape) | Injects the landscape identifier for workloads that need to know which environment they run in | Yes | Yes |
 
 > ### Tip:
 > To enable all available features at once, use the shorthand annotation [`rt-cfg.kyma-project.io/all: "true"`](#rt-cfg.kyma-project.io/all) on either a namespace or a Pod.
-
-> ## Note
-> In the US Sovereign Cloud (NS2) environment, the CA bundle injection (rt-cfg.kyma-project.io/add-cluster-trust-bundle) is the primary feature you need. The other features — image registry rewriting, pull secret injection, FIPS mode, and landscape identification — are only required in special cases and can be ignored for common deployments.
 
 ---
 
@@ -110,10 +107,6 @@ If the Secret reference is already present, it is not added again.
 The annotation mounts the cluster's TLS certificate bundle into your containers.
 
 Some landscapes use custom TLS certificates that are not included in the standard operating system trust store. When this feature is enabled, Runtime Bootstrapper mounts the cluster's certificate bundle as a read-only volume into every container (including init-containers) under the path `/etc/ssl/certs`. With this, your application can trust landscape-specific HTTPS endpoints without any code changes.
-
-> **CA bundle ownership (NS2):** The CA bundle is managed by the NS2 operator team, not by individual application teams. If TLS communication between your workloads and SAP backends fails due to missing or outdated certificates, you must involve the NS2 operator team to issue a suitable replacement certificate. Once a new certificate is available, the Kyma team updates the CA bundle in its configuration so it becomes accessible on Kyma runtimes.
->
-> **Hint:** Certificate changes must be handled via a service request. Make sure to inform the Kyma SRE team about any such changes so they can update the CA bundle configuration on the Kyma runtimes in a timely manner.
 
 The annotation causes the following changes in your Pod:
 

--- a/docs/user/01-runtime-bootstrapper.md
+++ b/docs/user/01-runtime-bootstrapper.md
@@ -60,7 +60,7 @@ Both levels can be combined. If a feature is enabled on a namespace, all Pods in
 
 Each annotation enables one specific feature. To activate it, set the value to `"true"`.
 
-| Annotation | Typical use case | NS2 (Sovereign Cloud) | CN |
+| Annotation | Typical use case | US Sovereign Cloud (NS2) | China (CN) |
 |---|---|---|---|
 | [`rt-cfg.kyma-project.io/add-cluster-trust-bundle`](#rt-cfgkyma-projectioadd-cluster-trust-bundle) | Mounts custom CA certificates required to trust SAP backend endpoints | Yes — primary feature. The CA bundle is managed by the NS2 operator team. If TLS communication fails due to missing or outdated certificates, involve the NS2 operator team to issue a replacement. Once available, the Kyma team updates the CA bundle in its configuration. Certificate changes must be handled via a service request — inform the Kyma SRE team so they can update the CA bundle on Kyma runtimes in time. | No |
 | [`rt-cfg.kyma-project.io/add-img-pull-secret`](#rt-cfgkyma-projectioadd-img-pull-secret) | Only relevant when pulling images from a private registry that requires authentication | No | Yes |
@@ -69,7 +69,7 @@ Each annotation enables one specific feature. To activate it, set the value to `
 | [`rt-cfg.kyma-project.io/set-landscape`](#rt-cfgkyma-projectioset-landscape) | Injects the landscape identifier for workloads that need to know which environment they run in | Yes | Yes |
 
 > ### Tip:
-> To enable all available features at once, use the shorthand annotation [`rt-cfg.kyma-project.io/all: "true"`](#rt-cfg.kyma-project.io/all) on either a namespace or a Pod.
+> To enable all available features at once, use the shorthand annotation [`rt-cfg.kyma-project.io/all: "true"`](#rt-cfgkyma-projectioall) on either a namespace or a Pod.
 
 ---
 

--- a/docs/user/01-runtime-bootstrapper.md
+++ b/docs/user/01-runtime-bootstrapper.md
@@ -14,6 +14,8 @@ You do not need to change your application code. All adjustments happen at Pod c
 ## Enabling Runtime Bootstrapper
 
 You can opt in to Runtime Bootstrapper features at two levels:
+- Annotating a namespace
+- Annotating a Pod or a Pod template
 
 ### Annotate a Namespace
 

--- a/docs/user/01-runtime-bootstrapper.md
+++ b/docs/user/01-runtime-bootstrapper.md
@@ -1,22 +1,23 @@
 # Runtime Bootstrapper
 
-## What Is the Runtime Bootstrapper?
+## What Is Runtime Bootstrapper?
 
-The Runtime Bootstrapper is a component that automatically adapts your workloads when they are deployed on SAP BTP, Kyma runtime. It runs transparently in the background and adjusts your Pods — and only your Pods — to meet the requirements of the specific landscape you are deploying into (for example, a landscape that uses a private container registry, requires FIPS-compliant workloads, or uses custom TLS certificates).
+Runtime Bootstrapper is a component that automatically adapts your workloads when they are deployed on SAP BTP, Kyma runtime. It runs transparently in the background and adjusts your Pods — and only your Pods — to meet the requirements of the specific landscape you are deploying into (for example, a landscape that uses a private container registry, requires FIPS-compliant workloads, or uses custom TLS certificates).
 
 You do not need to change your application code. All adjustments happen at Pod creation time, before the Pod starts running.
 
-> **Important:** The Runtime Bootstrapper only modifies **Pods**. It does not touch any other Kubernetes resources such as Deployments, Services, ConfigMaps, or Secrets.
+> ### Note:
+> Runtime Bootstrapper only modifies Pods. It does not touch any other Kubernetes resources, such as Deployments, Services, ConfigMaps, or Secrets.
 
 ---
 
-## How to Enable It
+## Enabling Runtime Bootstrapper
 
 You can opt in to Runtime Bootstrapper features at two levels:
 
-### Option 1: Annotate the Namespace
+### Annotate a Namespace
 
-Add one or more feature annotations to your Namespace. All Pods created in that namespace will automatically receive the corresponding adjustments — no changes to individual workload manifests are needed.
+Add one or more feature annotations to your namespace. As a result, all Pods created in that namespace automatically receive the corresponding adjustments, without requiring changes to individual workload manifests.
 
 ```yaml
 apiVersion: v1
@@ -28,9 +29,9 @@ metadata:
     rt-cfg.kyma-project.io/add-img-pull-secret: "true"
 ```
 
-### Option 2: Annotate the Pod (or Pod Template)
+### Annotate a Pod or a Pod Template
 
-Add annotations directly to your Pod or to the `spec.template.metadata.annotations` section of a Deployment, StatefulSet, or similar resource. Only that specific Pod (or Pods from that template) will be adjusted.
+Add annotations directly to your Pod or to the `spec.template.metadata.annotations` section of a Deployment, StatefulSet, or similar resource. As a result, only that specific Pod or Pods from that template are adjusted.
 
 ```yaml
 apiVersion: apps/v1
@@ -49,15 +50,16 @@ spec:
           image: my-registry.example.com/my-app:1.0.0
 ```
 
-Both levels can be combined. If a feature is enabled on the namespace, all Pods in that namespace benefit from it regardless of their own annotations.
+Both levels can be combined. If a feature is enabled on a namespace, all Pods in that namespace benefit from it regardless of their own annotations.
 
-> **Tip:** To enable all available features at once, use the shorthand annotation `rt-cfg.kyma-project.io/all: "true"` on either the namespace or the Pod.
+> ### Tip:
+> To enable all available features at once, use the shorthand annotation `rt-cfg.kyma-project.io/all: "true"` on either the namespace or the Pod.
 
 ---
 
 ## Supported Annotations
 
-Each annotation enables one specific feature. Set the value to `"true"` to activate it.
+Each annotation enables one specific feature. To activate it, set the value to `"true"`.
 
 > **Note for NS2 (Sovereign Cloud) customers:** The annotations listed below cover all configuration features supported by the Runtime Bootstrapper. In an NS2 environment, the CA bundle injection (`rt-cfg.kyma-project.io/add-cluster-trust-bundle`) is the primary feature you will need. The other features — image registry rewriting, pull secret injection, FIPS mode, and landscape identification — are only required in special cases and can be ignored for common deployments.
 
@@ -65,26 +67,26 @@ Each annotation enables one specific feature. Set the value to `"true"` to activ
 
 ### `rt-cfg.kyma-project.io/alter-img-registry`
 
-**What it does:** Rewrites the container registry host in image references.
+This annotation rewrites the container registry host in image references.
 
-Some landscapes require that container images are pulled from a private or landscape-specific registry instead of the original public registry. When this feature is enabled, the Runtime Bootstrapper automatically rewrites the registry hostname in the `image` field of every container and init-container in your Pod.
+Some landscapes require container images to be pulled from a private or landscape-specific registry rather than the original public registry. When this feature is enabled, Runtime Bootstrapper automatically rewrites the registry hostname in the **image** field of every container and init-container in your Pod.
 
-**What changes in your Pod:**
+The annotation causes the following changes in your Pod:
 
 - `.spec.containers[*].image` — registry hostname is replaced
 - `.spec.initContainers[*].image` — registry hostname is replaced
 
-You do not need to know the target registry address; this is configured centrally for the landscape.
+You don't need to know the target registry address, because it's configured centrally for the landscape.
 
 ---
 
 ### `rt-cfg.kyma-project.io/add-img-pull-secret`
 
-**What it does:** Injects image pull credentials into your Pod.
+This annotation injects image pull credentials into your Pod.
 
-When a private container registry requires authentication, the Runtime Bootstrapper adds a reference to the landscape's image pull Secret (`registry-credentials`) to your Pod. This ensures your Pod can pull images without you having to manage registry credentials yourself.
+When a private container registry requires authentication, Runtime Bootstrapper adds a reference to the landscape's image pull Secret (`registry-credentials`) to your Pod. This ensures your Pod can pull images without you having to manage registry credentials yourself.
 
-**What changes in your Pod:**
+The annotation causes the following change in your Pod:
 
 - `.spec.imagePullSecrets[]` — entry `registry-credentials` is appended
 
@@ -94,55 +96,59 @@ If the Secret reference is already present, it is not added again.
 
 ### `rt-cfg.kyma-project.io/add-cluster-trust-bundle`
 
-**What it does:** Mounts the cluster's TLS certificate bundle into your containers.
+The annotation mounts the cluster's TLS certificate bundle into your containers.
 
-Some landscapes use custom TLS certificates that are not included in the standard operating system trust store. When this feature is enabled, the Runtime Bootstrapper mounts the cluster's certificate bundle as a read-only volume into every container (including init-containers) under the path `/etc/ssl/certs`. This allows your application to trust landscape-specific HTTPS endpoints without any code changes.
+Some landscapes use custom TLS certificates that are not included in the standard operating system trust store. When this feature is enabled, Runtime Bootstrapper mounts the cluster's certificate bundle as a read-only volume into every container (including init-containers) under the path `/etc/ssl/certs`. With this, your application can trust landscape-specific HTTPS endpoints without any code changes.
 
 > **CA bundle ownership (NS2):** The CA bundle is managed by the NS2 operator team, not by individual application teams. If TLS communication between your workloads and SAP backends fails due to missing or outdated certificates, you must involve the NS2 operator team to issue a suitable replacement certificate. Once a new certificate is available, the Kyma team updates the CA bundle in its configuration so it becomes accessible on Kyma runtimes.
 >
 > **Hint:** Certificate changes must be handled via a service request. Make sure to inform the Kyma SRE team about any such changes so they can update the CA bundle configuration on the Kyma runtimes in a timely manner.
 
-**What changes in your Pod:**
+The annotation causes the following changes in your Pod:
 
 - `.spec.volumes[]` — a projected volume named `rt-bootstrapper-certs` is added
 - `.spec.containers[*].volumeMounts` — the volume is mounted read-only at `/etc/ssl/certs`
 - `.spec.initContainers[*].volumeMounts` — same mount applied to init-containers
 
-> **Important — certificate rotation:** The mounted CA bundle can change over time. Certificates are rotated periodically for security reasons, and the file at `/etc/ssl/certs` will be updated in place without restarting your Pod. Most application runtimes load TLS trust stores once at startup and do not automatically pick up changes from the filesystem. If your application is not aware of this, it will start rejecting HTTPS connections to landscape endpoints after a rotation event.
->
-> To handle certificate rotation, choose one of the following approaches:
->
-> - **Watch for file changes inside your application.** Implement a file watcher that detects changes under `/etc/ssl/certs` and reloads the trust store at runtime without restarting the process. This is the most resilient approach and avoids any downtime.
-> - **Trigger an externally managed restart.** Use a controller that watches the underlying `ClusterTrustBundle` resource and automatically rolls your workload when it changes. This is conceptually similar to how [stakater/Reloader](https://github.com/stakater/Reloader) restarts Pods when a referenced ConfigMap or Secret changes. A restart ensures the new certificate is loaded, at the cost of a brief interruption.
+#### Certificate Rotation
+
+> ### Caution:
+> The mounted CA bundle can change over time. Certificates are rotated periodically for security reasons, and the file at `/etc/ssl/certs` is updated in place without restarting your Pod. Most application runtimes load TLS trust stores once at startup and do not automatically pick up changes from the filesystem. If your application is not aware of this, it starts rejecting HTTPS connections to landscape endpoints after a rotation event.
+
+To handle certificate rotation, choose one of the following approaches:
+
+- Watch for file changes inside your application:  Implement a file watcher that detects changes under `/etc/ssl/certs` and reloads the trust store at runtime without restarting the process. This is the most resilient approach and avoids any downtime.
+- Trigger an externally managed restart: Use a controller that watches the underlying `ClusterTrustBundle` resource and automatically rolls your workload when it changes. This is conceptually similar to how [stakater/Reloader](https://github.com/stakater/Reloader) restarts Pods when a referenced ConfigMap or Secret changes. A restart ensures the new certificate is loaded, at the cost of a brief interruption.
 
 ---
 
 ### `rt-cfg.kyma-project.io/set-fips-mode`
 
-**What it does:** Signals FIPS 140 compliance mode to your workloads.
+This annotation signals FIPS 140 compliance mode to your workloads.
 
-FIPS (Federal Information Processing Standards) mode restricts cryptographic operations to approved algorithms. When this feature is enabled, the Runtime Bootstrapper sets two environment variables in every container and init-container. Your application can read these variables to activate its own FIPS-compliant code paths.
+Federal Information Processing Standards (FIPS) mode restricts cryptographic operations to approved algorithms. When this feature is enabled, Runtime Bootstrapper sets two environment variables in every container and init-container. Your application can read these variables to activate its own FIPS-compliant code paths.
 
-**What changes in your Pod:**
+The annotation causes the following changes in your Pod:
 
 - `.spec.containers[*].env[]` — the following variables are added to every container:
   - `KYMA_FIPS_MODE_ENABLED=true`
   - `FIPS_MODE_ENABLED=true` *(legacy compatibility)*
-- `.spec.initContainers[*].env[]` — same variables added to init-containers
+- `.spec.initContainers[*].env[]` — the following variables are added to init-containers:
+  - `KYMA_FIPS_MODE_ENABLED=true`
+  - `FIPS_MODE_ENABLED=true` *(legacy compatibility)*
 
 ---
 
 ### `rt-cfg.kyma-project.io/set-landscape`
 
-**What it does:** Injects the landscape identifier into your containers.
+This annotation injects the landscape identifier into your containers.
 
-Some applications need to know which landscape they are running on to adjust their behavior (for example, to point to the correct backend endpoint or to display the correct region label). When this feature is enabled, the Runtime Bootstrapper injects the landscape identifier as an environment variable into every container and init-container.
+Some applications must know which landscape they are running on to adjust their behavior (for example, to point to the correct backend endpoint or to display the correct region label). When this feature is enabled, Runtime Bootstrapper injects the landscape identifier as an environment variable into every container and init-container.
 
-**What changes in your Pod:**
+The annotation causes the following changes in your Pod:
 
-- `.spec.containers[*].env[]` — the following variable is added:
-  - `KYMA_LANDSCAPE=<landscape-identifier>`
-- `.spec.initContainers[*].env[]` — same variable added to init-containers
+- `.spec.containers[*].env[]` - the `KYMA_LANDSCAPE=<landscape-identifier>` variable is added
+- `.spec.initContainers[*].env[]` - the `KYMA_LANDSCAPE=<landscape-identifier>` variable is added
 
 The actual value of the landscape identifier is provided by the landscape operator and is not configurable by the workload owner.
 
@@ -150,7 +156,7 @@ The actual value of the landscape identifier is provided by the landscape operat
 
 ### `rt-cfg.kyma-project.io/all`
 
-**What it does:** Shorthand to enable all available features at once.
+The annotation is a shorthand to enable all available features at once.
 
 Setting this annotation to `"true"` is equivalent to setting every feature annotation listed above. Use it when you want your namespace or Pod to receive all landscape adaptations without listing them individually.
 
@@ -163,13 +169,13 @@ annotations:
 
 ## Confirming a Pod Was Modified
 
-After the Runtime Bootstrapper processes a Pod, it adds the following annotation to the Pod metadata:
+After Runtime Bootstrapper processes a Pod, it adds the following annotation to the Pod metadata:
 
 ```
 rt-bootstrapper.kyma-project.io/modified: "true"
 ```
 
-You can verify this with:
+To verify this, replace the placeholder and run:
 
 ```sh
 kubectl get pod <pod-name> -o jsonpath='{.metadata.annotations.rt-bootstrapper\.kyma-project\.io/modified}'
@@ -177,15 +183,3 @@ kubectl get pod <pod-name> -o jsonpath='{.metadata.annotations.rt-bootstrapper\.
 
 If the output is `true`, the Pod was successfully processed.
 
----
-
-## Summary Table
-
-| Annotation | What it enables |
-|---|---|
-| `rt-cfg.kyma-project.io/alter-img-registry: "true"` | Rewrite container image registry hostnames |
-| `rt-cfg.kyma-project.io/add-img-pull-secret: "true"` | Inject image pull Secret (`registry-credentials`) |
-| `rt-cfg.kyma-project.io/add-cluster-trust-bundle: "true"` | Mount cluster TLS certificates at `/etc/ssl/certs` |
-| `rt-cfg.kyma-project.io/set-fips-mode: "true"` | Set `KYMA_FIPS_MODE_ENABLED` and `FIPS_MODE_ENABLED` env vars |
-| `rt-cfg.kyma-project.io/set-landscape: "true"` | Set `KYMA_LANDSCAPE` env var |
-| `rt-cfg.kyma-project.io/all: "true"` | Enable all of the above |

--- a/docs/user/01-runtime-bootstrapper.md
+++ b/docs/user/01-runtime-bootstrapper.md
@@ -17,7 +17,7 @@ You can opt in to Runtime Bootstrapper features at two levels:
 - Annotating a namespace
 - Annotating a Pod or a Pod template
 
-### Annotate a Namespace
+### Annotating a Namespace
 
 Add one or more feature annotations to your namespace. As a result, all Pods created in that namespace automatically receive the corresponding adjustments, without requiring changes to individual workload manifests.
 
@@ -31,7 +31,7 @@ metadata:
     rt-cfg.kyma-project.io/add-img-pull-secret: "true"
 ```
 
-### Annotate a Pod or a Pod Template
+### Annotating a Pod or a Pod Template
 
 Add annotations directly to your Pod or to the `spec.template.metadata.annotations` section of a Deployment, StatefulSet, or similar resource. As a result, only that specific Pod or Pods from that template are adjusted.
 
@@ -54,9 +54,6 @@ spec:
 
 Both levels can be combined. If a feature is enabled on a namespace, all Pods in that namespace benefit from it regardless of their own annotations.
 
-> ### Tip:
-> To enable all available features at once, use the shorthand annotation `rt-cfg.kyma-project.io/all: "true"` on either the namespace or the Pod.
-
 ---
 
 ## Supported Annotations
@@ -71,7 +68,11 @@ Each annotation enables one specific feature. To activate it, set the value to `
 | [`rt-cfg.kyma-project.io/set-fips-mode`](#rt-cfgkyma-projectioset-fips-mode) | Primarily NS2-related — signals to workloads that FIPS 140-compliant cryptography should be used |
 | [`rt-cfg.kyma-project.io/set-landscape`](#rt-cfgkyma-projectioset-landscape) | Injects the landscape identifier for workloads that need to know which environment they run in |
 
-> **Note for NS2 (Sovereign Cloud) customers:** The annotations listed below cover all configuration features supported by the Runtime Bootstrapper. In an NS2 environment, the CA bundle injection (`rt-cfg.kyma-project.io/add-cluster-trust-bundle`) is the primary feature you will need. The other features — image registry rewriting, pull secret injection, FIPS mode, and landscape identification — are only required in special cases and can be ignored for common deployments.
+> ### Tip:
+> To enable all available features at once, use the shorthand annotation [`rt-cfg.kyma-project.io/all: "true"`](#rt-cfg.kyma-project.io/all) on either a namespace or a Pod.
+
+> ## Note
+> In the US Sovereign Cloud (NS2) environment, the CA bundle injection (rt-cfg.kyma-project.io/add-cluster-trust-bundle) is the primary feature you need. The other features — image registry rewriting, pull secret injection, FIPS mode, and landscape identification — are only required in special cases and can be ignored for common deployments.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds end-user documentation for Runtime Bootstrapper, targeting application developers deploying workloads on SAP BTP, Kyma runtime.

The new page (`docs/user/01-runtime-bootstrapper.md`) covers:

- **What the Runtime Bootstrapper does** — transparently patches Pods at admission time to meet landscape requirements (private registry, custom TLS certificates, FIPS mode, landscape identity injection). No application code changes needed.
- **How to opt in** — namespace-level and Pod/template-level annotation examples, including the `rt-cfg.kyma-project.io/all` shorthand.
- **Supported annotations** — per-annotation explanation of what changes inside the Pod spec (`image`, `imagePullSecrets`, `volumeMounts`, `env`):
  - `alter-img-registry` — rewrites container image registry hostnames
  - `add-img-pull-secret` — injects `registry-credentials` pull secret
  - `add-cluster-trust-bundle` — mounts cluster CA bundle at `/etc/ssl/certs`; includes guidance on handling certificate rotation (file watcher vs. workload restart)
  - `set-fips-mode` — sets `KYMA_FIPS_MODE_ENABLED` and `FIPS_MODE_ENABLED` env vars
  - `set-landscape` — injects `KYMA_LANDSCAPE` env var
- **Verification** — how to confirm a Pod was processed via the `rt-bootstrapper.kyma-project.io/modified` annotation.
- **Summary table** of all annotations for quick reference.