### PR TITLE
Fix auditFeatures logic and make SecretReconciler feature-gate dynamic

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -297,6 +297,7 @@ func main() {
 			Namespace: imagePullSecretNamespace,
 		},
 		SecretSyncInterval: time.Duration(secretSyncInterval),
+		GetConfig:          readConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Secret")
 		os.Exit(1)

--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -42,6 +43,7 @@ type SecretReconciler struct {
 	Scheme *runtime.Scheme
 	types.NamespacedName
 	SecretSyncInterval time.Duration
+	GetConfig          func(context.Context) (*apiv1.Config, error)
 }
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;patch
@@ -51,6 +53,14 @@ const (
 )
 
 func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+
+	cfg, err := r.GetConfig(ctx)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to read config: %w", err)
+	}
+	if !slices.Contains(cfg.AvailableFeatures, apiv1.AnnotationSetPullSecret) {
+		return ctrl.Result{}, nil
+	}
 
 	isMasterSecretUpdated := req.Namespace == r.Namespace && req.Name == r.Name
 	isCredentialsSecretUpdated := (req.Namespace != "" && req.Namespace != r.Namespace) && req.Name == r.Name

--- a/internal/controller/secret_controller_test.go
+++ b/internal/controller/secret_controller_test.go
@@ -17,7 +17,17 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 var _ = Describe("Secret Controller", func() {
@@ -27,6 +37,42 @@ var _ = Describe("Secret Controller", func() {
 
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+
+	Context("Reconcile feature gate", func() {
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-ns"}}
+
+		It("should skip reconcile when AnnotationSetPullSecret is not in availableFeatures", func() {
+			r := &SecretReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+				NamespacedName: types.NamespacedName{Name: "registry-credentials", Namespace: "kyma-system"},
+				GetConfig: func(_ context.Context) (*apiv1.Config, error) {
+					return &apiv1.Config{
+						Overrides:         map[string]string{},
+						AvailableFeatures: []string{apiv1.AnnotationAlterImgRegistry},
+					}, nil
+				},
+			}
+
+			result, err := r.Reconcile(ctx, req)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result).Should(Equal(ctrl.Result{}))
+		})
+
+		It("should return error when GetConfig fails", func() {
+			configErr := errors.New("configmap not found")
+			r := &SecretReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+				NamespacedName: types.NamespacedName{Name: "registry-credentials", Namespace: "kyma-system"},
+				GetConfig: func(_ context.Context) (*apiv1.Config, error) {
+					return nil, configErr
+				},
+			}
+
+			_, err := r.Reconcile(ctx, req)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("configmap not found"))
 		})
 	})
 })

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -129,8 +129,8 @@ func (s annotationSources) auditFeatures(availableFeatures []string) {
 	for _, src := range s {
 		for key := range src.annotations {
 			isAvailableFeature := slices.Contains(availableFeatures, key)
-			isRtBootstrapperFeature := strings.HasPrefix(key, "rt-bootstrapper.kyma-project.io/")
-			if !isAvailableFeature && !isRtBootstrapperFeature {
+			isRtBootstrapperFeature := strings.HasPrefix(key, "rt-cfg.kyma-project.io/")
+			if !isAvailableFeature && isRtBootstrapperFeature {
 				slog.Warn("found inactive feature", "key", key)
 			}
 		}

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -244,34 +244,4 @@ var _ = Describe("Pod Webhook", func() {
 			Expect(pod.Annotations[apiv1.AnnotationModified]).Should(Equal("true"))
 		})
 	})
-
-	Context("auditFeatures", func() {
-		It("Should warn on inactive rt-cfg feature annotation", func() {
-			src := annotationSources{
-				{level: "pod", annotations: map[string]string{
-					apiv1.AnnotationSetPullSecret: "true",
-				}},
-			}
-			src.auditFeatures([]string{apiv1.AnnotationAlterImgRegistry})
-		})
-
-		It("Should not warn on third-party annotations", func() {
-			src := annotationSources{
-				{level: "ns", annotations: map[string]string{
-					"resources.gardener.cloud/origin":                  "some-value",
-					"kubectl.kubernetes.io/last-applied-configuration": "{}",
-				}},
-			}
-			src.auditFeatures([]string{})
-		})
-
-		It("Should not warn on active rt-cfg feature annotation", func() {
-			src := annotationSources{
-				{level: "pod", annotations: map[string]string{
-					apiv1.AnnotationSetPullSecret: "true",
-				}},
-			}
-			src.auditFeatures([]string{apiv1.AnnotationSetPullSecret})
-		})
-	})
 })

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -244,4 +244,40 @@ var _ = Describe("Pod Webhook", func() {
 			Expect(pod.Annotations[apiv1.AnnotationModified]).Should(Equal("true"))
 		})
 	})
+
+	Context("auditFeatures", func() {
+		It("Should warn on inactive rt-cfg feature annotation", func() {
+			src := annotationSources{
+				{level: "pod", annotations: map[string]string{
+					apiv1.AnnotationSetPullSecret: "true",
+				}},
+			}
+			Expect(func() {
+				src.auditFeatures([]string{apiv1.AnnotationAlterImgRegistry})
+			}).ShouldNot(Panic())
+		})
+
+		It("Should not warn on third-party annotations", func() {
+			src := annotationSources{
+				{level: "ns", annotations: map[string]string{
+					"resources.gardener.cloud/origin":                  "some-value",
+					"kubectl.kubernetes.io/last-applied-configuration": "{}",
+				}},
+			}
+			Expect(func() {
+				src.auditFeatures([]string{})
+			}).ShouldNot(Panic())
+		})
+
+		It("Should not warn on active rt-cfg feature annotation", func() {
+			src := annotationSources{
+				{level: "pod", annotations: map[string]string{
+					apiv1.AnnotationSetPullSecret: "true",
+				}},
+			}
+			Expect(func() {
+				src.auditFeatures([]string{apiv1.AnnotationSetPullSecret})
+			}).ShouldNot(Panic())
+		})
+	})
 })

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -246,38 +246,32 @@ var _ = Describe("Pod Webhook", func() {
 	})
 
 	Context("auditFeatures", func() {
-		It("Should warn on inactive rt-cfg feature annotation", func() {
+		It("Should not panic on inactive rt-cfg feature annotation", func() {
 			src := annotationSources{
 				{level: "pod", annotations: map[string]string{
 					apiv1.AnnotationSetPullSecret: "true",
 				}},
 			}
-			Expect(func() {
-				src.auditFeatures([]string{apiv1.AnnotationAlterImgRegistry})
-			}).ShouldNot(Panic())
+			src.auditFeatures([]string{apiv1.AnnotationAlterImgRegistry})
 		})
 
-		It("Should not warn on third-party annotations", func() {
+		It("Should not panic on third-party annotations", func() {
 			src := annotationSources{
 				{level: "ns", annotations: map[string]string{
 					"resources.gardener.cloud/origin":                  "some-value",
 					"kubectl.kubernetes.io/last-applied-configuration": "{}",
 				}},
 			}
-			Expect(func() {
-				src.auditFeatures([]string{})
-			}).ShouldNot(Panic())
+			src.auditFeatures([]string{})
 		})
 
-		It("Should not warn on active rt-cfg feature annotation", func() {
+		It("Should not panic on active rt-cfg feature annotation", func() {
 			src := annotationSources{
 				{level: "pod", annotations: map[string]string{
 					apiv1.AnnotationSetPullSecret: "true",
 				}},
 			}
-			Expect(func() {
-				src.auditFeatures([]string{apiv1.AnnotationSetPullSecret})
-			}).ShouldNot(Panic())
+			src.auditFeatures([]string{apiv1.AnnotationSetPullSecret})
 		})
 	})
 })

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -246,7 +246,7 @@ var _ = Describe("Pod Webhook", func() {
 	})
 
 	Context("auditFeatures", func() {
-		It("Should not panic on inactive rt-cfg feature annotation", func() {
+		It("Should warn on inactive rt-cfg feature annotation", func() {
 			src := annotationSources{
 				{level: "pod", annotations: map[string]string{
 					apiv1.AnnotationSetPullSecret: "true",
@@ -255,7 +255,7 @@ var _ = Describe("Pod Webhook", func() {
 			src.auditFeatures([]string{apiv1.AnnotationAlterImgRegistry})
 		})
 
-		It("Should not panic on third-party annotations", func() {
+		It("Should not warn on third-party annotations", func() {
 			src := annotationSources{
 				{level: "ns", annotations: map[string]string{
 					"resources.gardener.cloud/origin":                  "some-value",
@@ -265,7 +265,7 @@ var _ = Describe("Pod Webhook", func() {
 			src.auditFeatures([]string{})
 		})
 
-		It("Should not panic on active rt-cfg feature annotation", func() {
+		It("Should not warn on active rt-cfg feature annotation", func() {
 			src := annotationSources{
 				{level: "pod", annotations: map[string]string{
 					apiv1.AnnotationSetPullSecret: "true",


### PR DESCRIPTION
Closes #164
Closes #166

## Summary

- Fix inverted condition and wrong prefix in `auditFeatures`: was warning on all non-rt-bootstrapper annotations (e.g. `resources.gardener.cloud/origin`); now correctly warns only on `rt-cfg.kyma-project.io/` keys not in `availableFeatures`
- Add `GetConfig` to `SecretReconciler` and check `AnnotationSetPullSecret` at reconcile time instead of at startup, so the feature gate responds to config changes without requiring a pod restart

## Test plan

- [ ] Verify no spurious `found inactive feature` warnings for third-party annotations (e.g. `resources.gardener.cloud/origin`) in prod logs
- [ ] Verify `found inactive feature` warning still fires for an `rt-cfg.kyma-project.io/` annotation not in `availableFeatures`
- [ ] On a cluster without `AnnotationSetPullSecret` in `availableFeatures`, create a namespace and confirm no secret sync error
- [ ] On a cluster with `AnnotationSetPullSecret` in `availableFeatures`, confirm secret sync still works on namespace creation
- [ ] Update config to add/remove `AnnotationSetPullSecret` and confirm reconciler picks up the change without a restart