### PR TITLE
feat: add PR tag to build_image workflow

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -44,6 +44,7 @@ jobs:
     outputs:
       tag: ${{ steps.tag.outputs.tag || '' }}
       latest: ${{ steps.latest.outputs.latest || '' }}
+      pr-tag: ${{ steps.pr-tag.outputs.pr-tag || '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -56,6 +57,9 @@ jobs:
       - id: latest
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name == 'push'
         run: echo "latest=latest" >> $GITHUB_OUTPUT
+      - id: pr-tag
+        if: github.event_name == 'pull_request_target'
+        run: echo "pr-tag=0.0.0-PR.${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
 
   build-image:
     name: run-image-builder
@@ -69,6 +73,7 @@ jobs:
       tags: |
         ${{ needs.setup.outputs.tag }}
         ${{ needs.setup.outputs.latest }}
+        ${{ needs.setup.outputs.pr-tag }}
 
   summary:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -59,7 +59,7 @@ jobs:
         run: echo "latest=latest" >> $GITHUB_OUTPUT
       - id: pr-tag
         if: github.event_name == 'pull_request_target'
-        run: echo "pr-tag=0.0.0-PR.${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+        run: echo "pr-tag=0.0.0-PR-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
 
   build-image:
     name: run-image-builder

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ dist
 
 # vendored files
 vendor
+.superpowers/

--- a/docs/superpowers/plans/2026-07-01-pr-tag-build-image.md
+++ b/docs/superpowers/plans/2026-07-01-pr-tag-build-image.md
@@ -1,0 +1,120 @@
+# PR Tag in build_image.yml Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `pr-tag` output (`0.0.0-PR.<number>`) to the `setup` job in `.github/workflows/build_image.yml` so PR builds get a semver-valid image tag instead of none.
+
+**Architecture:** Single file change — add one job output, one step, and one line to the `tags` multiline input. No new files. Follows the exact pattern of the existing `tag` and `latest` outputs.
+
+**Tech Stack:** GitHub Actions YAML
+
+## Global Constraints
+
+- Tag format must satisfy: `^[v]?(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
+- Exact format: `0.0.0-PR.<pr-number>` (e.g. `0.0.0-PR.42`)
+- Only fires on `pull_request_target` events
+- Must not affect push-to-main or push-tag event behavior
+- No changes to any file other than `.github/workflows/build_image.yml`
+
+---
+
+### Task 1: Add `pr-tag` output and step to `setup` job, pass to `build-image`
+
+**Files:**
+- Modify: `.github/workflows/build_image.yml:44-71`
+
+**Interfaces:**
+- Produces: `needs.setup.outputs.pr-tag` — string value `0.0.0-PR.<number>` or empty string
+
+- [ ] **Step 1: Add the `pr-tag` output declaration to the `setup` job**
+
+In `.github/workflows/build_image.yml`, find the `outputs:` block of the `setup` job (currently lines 44-46) and add the new output:
+
+```yaml
+    outputs:
+      tag: ${{ steps.tag.outputs.tag || '' }}
+      latest: ${{ steps.latest.outputs.latest || '' }}
+      pr-tag: ${{ steps.pr-tag.outputs.pr-tag || '' }}
+```
+
+- [ ] **Step 2: Add the `pr-tag` step to the `setup` job**
+
+After the existing `latest` step (currently line 58), add:
+
+```yaml
+      - id: pr-tag
+        if: github.event_name == 'pull_request_target'
+        run: echo "pr-tag=0.0.0-PR.${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+```
+
+- [ ] **Step 3: Add `pr-tag` to the `build-image` `tags` input**
+
+In the `build-image` job, find the `tags:` multiline input (currently lines 69-71) and add the new output as a third line:
+
+```yaml
+      tags: |
+        ${{ needs.setup.outputs.tag }}
+        ${{ needs.setup.outputs.latest }}
+        ${{ needs.setup.outputs.pr-tag }}
+```
+
+- [ ] **Step 4: Verify the final file looks correct**
+
+The complete `setup` job outputs block and steps, and the `build-image` tags input, should read:
+
+```yaml
+  setup:
+    needs: [gate]
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag || '' }}
+      latest: ${{ steps.latest.outputs.latest || '' }}
+      pr-tag: ${{ steps.pr-tag.outputs.pr-tag || '' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - id: tag
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        run: echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+      - id: latest
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name == 'push'
+        run: echo "latest=latest" >> $GITHUB_OUTPUT
+      - id: pr-tag
+        if: github.event_name == 'pull_request_target'
+        run: echo "pr-tag=0.0.0-PR.${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+
+  build-image:
+    name: run-image-builder
+    needs: [setup, gate]
+    if: ${{ !cancelled() && needs.setup.result == 'success' && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
+    uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+    with:
+      name: rt-bootstrapper
+      dockerfile: Dockerfile
+      context: .
+      tags: |
+        ${{ needs.setup.outputs.tag }}
+        ${{ needs.setup.outputs.latest }}
+        ${{ needs.setup.outputs.pr-tag }}
+```
+
+- [ ] **Step 5: Validate YAML syntax**
+
+Run:
+```bash
+python3 -c "import yaml, sys; yaml.safe_load(open('.github/workflows/build_image.yml'))" && echo "YAML valid"
+```
+Expected output: `YAML valid`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/build_image.yml
+git commit -m "feat: add PR tag to build_image workflow"
+```

--- a/docs/superpowers/plans/2026-07-01-pr-tag-build-image.md
+++ b/docs/superpowers/plans/2026-07-01-pr-tag-build-image.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add a `pr-tag` output (`0.0.0-PR.<number>`) to the `setup` job in `.github/workflows/build_image.yml` so PR builds get a semver-valid image tag instead of none.
+**Goal:** Add a `pr-tag` output (`0.0.0-PR-<number>`) to the `setup` job in `.github/workflows/build_image.yml` so PR builds get a semver-valid image tag instead of none.
 
 **Architecture:** Single file change — add one job output, one step, and one line to the `tags` multiline input. No new files. Follows the exact pattern of the existing `tag` and `latest` outputs.
 
@@ -11,7 +11,7 @@
 ## Global Constraints
 
 - Tag format must satisfy: `^[v]?(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
-- Exact format: `0.0.0-PR.<pr-number>` (e.g. `0.0.0-PR.42`)
+- Exact format: `0.0.0-PR-<pr-number>` (e.g. `0.0.0-PR-42`)
 - Only fires on `pull_request_target` events
 - Must not affect push-to-main or push-tag event behavior
 - No changes to any file other than `.github/workflows/build_image.yml`
@@ -24,7 +24,7 @@
 - Modify: `.github/workflows/build_image.yml:44-71`
 
 **Interfaces:**
-- Produces: `needs.setup.outputs.pr-tag` — string value `0.0.0-PR.<number>` or empty string
+- Produces: `needs.setup.outputs.pr-tag` — string value `0.0.0-PR-<number>` or empty string
 
 - [ ] **Step 1: Add the `pr-tag` output declaration to the `setup` job**
 
@@ -44,7 +44,7 @@ After the existing `latest` step (currently line 58), add:
 ```yaml
       - id: pr-tag
         if: github.event_name == 'pull_request_target'
-        run: echo "pr-tag=0.0.0-PR.${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+        run: echo "pr-tag=0.0.0-PR-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
 ```
 
 - [ ] **Step 3: Add `pr-tag` to the `build-image` `tags` input**
@@ -87,7 +87,7 @@ The complete `setup` job outputs block and steps, and the `build-image` tags inp
         run: echo "latest=latest" >> $GITHUB_OUTPUT
       - id: pr-tag
         if: github.event_name == 'pull_request_target'
-        run: echo "pr-tag=0.0.0-PR.${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+        run: echo "pr-tag=0.0.0-PR-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
 
   build-image:
     name: run-image-builder

--- a/docs/superpowers/specs/2026-07-01-pr-tag-build-image-design.md
+++ b/docs/superpowers/specs/2026-07-01-pr-tag-build-image-design.md
@@ -16,7 +16,7 @@ PR builds currently produce no version tag (`tag` output is empty on `pull_reque
 
 ## Solution
 
-Add a `pr-tag` output to the `setup` job that emits `0.0.0-PR.<number>` when the workflow runs on a `pull_request_target` event. This tag is mutually exclusive with the semver release tag.
+Add a `pr-tag` output to the `setup` job that emits `0.0.0-PR-<number>` when the workflow runs on a `pull_request_target` event. This tag is mutually exclusive with the semver release tag.
 
 ## Design
 
@@ -34,7 +34,7 @@ steps:
   # ... existing steps ...
   - id: pr-tag
     if: github.event_name == 'pull_request_target'
-    run: echo "pr-tag=0.0.0-PR.${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+    run: echo "pr-tag=0.0.0-PR-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
 ```
 
 ### `build-image` job
@@ -54,7 +54,7 @@ tags: |
 |---|---|---|---|
 | `push` + tag ref | `v1.2.3` | — | — |
 | `push` to main | — | `latest` | — |
-| `pull_request_target` | — | — | `0.0.0-PR.42` |
+| `pull_request_target` | — | — | `0.0.0-PR-42` |
 
 Empty outputs produce blank lines in the multiline `tags` input, which image-builder already handles safely (consistent with existing behavior).
 

--- a/docs/superpowers/specs/2026-07-01-pr-tag-build-image-design.md
+++ b/docs/superpowers/specs/2026-07-01-pr-tag-build-image-design.md
@@ -1,0 +1,64 @@
+---
+name: pr-tag-build-image
+description: Add a semver-compatible PR tag to the build_image.yml workflow as an alternative to the release tag
+metadata:
+  type: project
+---
+
+# PR Tag in build_image.yml
+
+## Problem
+
+The image-builder validates image tags against a semver pattern:
+`^[v]?(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-(...))?(?:\+(...))?$`
+
+PR builds currently produce no version tag (`tag` output is empty on `pull_request_target` events), making PR images harder to identify and reference.
+
+## Solution
+
+Add a `pr-tag` output to the `setup` job that emits `0.0.0-PR.<number>` when the workflow runs on a `pull_request_target` event. This tag is mutually exclusive with the semver release tag.
+
+## Design
+
+### `setup` job
+
+Add one output and one step:
+
+```yaml
+outputs:
+  tag: ${{ steps.tag.outputs.tag || '' }}
+  latest: ${{ steps.latest.outputs.latest || '' }}
+  pr-tag: ${{ steps.pr-tag.outputs.pr-tag || '' }}   # new
+
+steps:
+  # ... existing steps ...
+  - id: pr-tag
+    if: github.event_name == 'pull_request_target'
+    run: echo "pr-tag=0.0.0-PR.${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+```
+
+### `build-image` job
+
+Add the new output to the `tags` multiline input:
+
+```yaml
+tags: |
+  ${{ needs.setup.outputs.tag }}
+  ${{ needs.setup.outputs.latest }}
+  ${{ needs.setup.outputs.pr-tag }}
+```
+
+## Tag Behavior Per Event
+
+| Event | `tag` | `latest` | `pr-tag` |
+|---|---|---|---|
+| `push` + tag ref | `v1.2.3` | — | — |
+| `push` to main | — | `latest` | — |
+| `pull_request_target` | — | — | `0.0.0-PR.42` |
+
+Empty outputs produce blank lines in the multiline `tags` input, which image-builder already handles safely (consistent with existing behavior).
+
+## Out of Scope
+
+- No changes to `release.yml` or any other workflow.
+- No renaming of existing outputs.


### PR DESCRIPTION
## Summary

- Adds a `pr-tag` output (`0.0.0-PR.<pr-number>`) to the `setup` job in `.github/workflows/build_image.yml`
- The tag is emitted only on `pull_request_target` events and passed to the image-builder alongside the existing `tag` and `latest` outputs
- The three tags are mutually exclusive by event type: `tag` on push+tag-ref, `latest` on push-to-main, `pr-tag` on pull_request_target
- Tag format satisfies the required semver pattern: `0.0.0-PR.<number>`

## Test plan

- [ ] Trigger a `pull_request_target` event and verify the built image is tagged `0.0.0-PR.<pr-number>`
- [ ] Verify a push-to-main build still produces a `latest`-tagged image with no regressions
- [ ] Verify a release tag push still produces a semver-tagged image with no regressions