### PR TITLE
feat: support 'false' and 'restart-on-change' values for CTB annotation

### DIFF
--- a/internal/webhook/v1/pod_defaulters.go
+++ b/internal/webhook/v1/pod_defaulters.go
@@ -187,7 +187,27 @@ func BuildDefaulterAddClusterTrustBundle() PodDefaulter {
 		return handleContainers(true, p, c.ClusterTrustBundleMapping)
 	}
 
-	return defaultPod(handleClusterTrustBundle, updateOpts{
-		activeAnnotations: annotationAddClusterTrustBundle,
-	})
+	return func(p *corev1.Pod, nsAnnotations map[string]string, cfg *apiv1.Config) (bool, error) {
+		kvs := keysAndValues(p)
+
+		// Explicit opt-out: pod annotation "false" overrides everything, including namespace defaults.
+		if apiv1.CTBExplicitOptOut(p.Annotations) {
+			slog.Default().WithGroup("args").With(kvs...).Debug("CTB explicit opt out")
+			return false, nil
+		}
+
+		defaultFeatures := cfg.NamespaceDefaultFeatures(p.Namespace)
+		expandedNamespaceAnnotations := cfg.ExpandAnnotationAll(nsAnnotations)
+		expandedPodAnnotations := cfg.ExpandAnnotationAll(p.Annotations)
+
+		for _, annotations := range []map[string]string{defaultFeatures, expandedNamespaceAnnotations, expandedPodAnnotations} {
+			if apiv1.CTBMountEnabled(annotations) || k8s.Contains(annotations, annotationAddClusterTrustBundle) {
+				slog.Default().WithGroup("args").With(kvs...).Debug("CTB pod defaulting opt in")
+				return handleClusterTrustBundle(p, cfg), nil
+			}
+		}
+
+		slog.Default().WithGroup("args").With(kvs...).Debug("CTB opt out")
+		return false, nil
+	}
 }

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kyma-project/rt-bootstrapper/internal/webhook/k8s"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -198,7 +199,112 @@ var _ = Describe("Pod Webhook", func() {
 				corev1.LocalObjectReference{Name: testPullSecret},
 			))
 		})
+	}) // end Context("When creating Pod under Defaulting Webhook")
 
+	Context("ClusterTrustBundle annotation values", func() {
+		ctbMapping := &k8s.ClusterTrustBundle{
+			Name:            "test-ctb",
+			CertWritePath:   "ca.pem",
+			VolumeMountPath: "/etc/ssl/certs",
+			VolumeName:      "rt-bootstrapper-certs",
+		}
+
+		cfgCTB := &apiv1.Config{
+			NamespaceFeatures:         &apiv1.NamespaceFeatures{},
+			Overrides:                 map[string]string{},
+			ClusterTrustBundleMapping: ctbMapping,
+			AvailableFeatures: []string{
+				apiv1.AnnotationAddClusterTrustBundle,
+			},
+		}
+
+		d3 := BuildDefaulterAddClusterTrustBundle()
+
+		defaulterCTB := podCustomDefaulter{
+			availableFeatures: []string{
+				apiv1.AnnotationAddClusterTrustBundle,
+			},
+			defaulters: []PodDefaulter{d3},
+			GetNsAnnotations: func(_ context.Context, name string) (map[string]string, error) {
+				return nil, nil
+			},
+			GetConfig: func(_ context.Context) (*apiv1.Config, error) {
+				return cfgCTB, nil
+			},
+			namespaceDefaultFeatures: cfgCTB.NamespaceDefaultFeatures,
+		}
+
+		It("Should mount CTB when annotation is 'true'", func() {
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "true",
+			})
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Spec.Volumes).Should(HaveLen(1))
+			Expect(pod.Spec.Volumes[0].Name).Should(Equal("rt-bootstrapper-certs"))
+		})
+
+		It("Should mount CTB when annotation is 'restart-on-change'", func() {
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+			})
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Spec.Volumes).Should(HaveLen(1))
+			Expect(pod.Spec.Volumes[0].Name).Should(Equal("rt-bootstrapper-certs"))
+		})
+
+		It("Should NOT mount CTB when annotation is 'false'", func() {
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "false",
+			})
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Spec.Volumes).Should(BeEmpty())
+		})
+
+		It("Should NOT mount CTB when annotation is 'false' even with namespace defaults", func() {
+			nsFeat := apiv1.NamespaceFeatures{
+				"kyma-system": {apiv1.AnnotationAddClusterTrustBundle},
+			}
+			cfgNS := &apiv1.Config{
+				NamespaceFeatures:         &nsFeat,
+				Overrides:                 map[string]string{},
+				ClusterTrustBundleMapping: ctbMapping,
+				AvailableFeatures: []string{
+					apiv1.AnnotationAddClusterTrustBundle,
+				},
+			}
+
+			defaulterNS := podCustomDefaulter{
+				availableFeatures: []string{
+					apiv1.AnnotationAddClusterTrustBundle,
+				},
+				defaulters: []PodDefaulter{BuildDefaulterAddClusterTrustBundle()},
+				GetNsAnnotations: func(_ context.Context, name string) (map[string]string, error) {
+					return nil, nil
+				},
+				GetConfig: func(_ context.Context) (*apiv1.Config, error) {
+					return cfgNS, nil
+				},
+				namespaceDefaultFeatures: cfgNS.NamespaceDefaultFeatures,
+			}
+
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "false",
+			})
+			pod.Namespace = "kyma-system"
+
+			err := defaulterNS.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Spec.Volumes).Should(BeEmpty())
+		})
+	})
+
+	Context("When creating Pod under Defaulting Webhook", func() {
 		It("Should inject landscape env var", func() {
 			d5 := BuildDefaulterSetLandscape("NS2")
 			cfgLandscape := &apiv1.Config{

--- a/pkg/api/v1/ctb_values.go
+++ b/pkg/api/v1/ctb_values.go
@@ -19,6 +19,12 @@ func CTBMountEnabled(annotations map[string]string) bool {
 	return v == CTBValueTrue || v == CTBValueRestartOnChange
 }
 
+// CTBExplicitOptOut returns true if the pod explicitly opts out via "false".
+func CTBExplicitOptOut(annotations map[string]string) bool {
+	v, ok := annotations[AnnotationAddClusterTrustBundle]
+	return ok && v == CTBValueFalse
+}
+
 // CTBRestartEnabled returns true if the annotation value signals that the
 // pod should be restarted when the CTB CA changes.
 func CTBRestartEnabled(annotations map[string]string) bool {

--- a/pkg/api/v1/ctb_values.go
+++ b/pkg/api/v1/ctb_values.go
@@ -1,0 +1,30 @@
+package v1
+
+const (
+	// CTBValueTrue enables CTB volume mounting (existing behavior).
+	CTBValueTrue = "true"
+	// CTBValueFalse explicitly opts out of CTB volume mounting.
+	CTBValueFalse = "false"
+	// CTBValueRestartOnChange enables CTB mounting and controller-managed restart.
+	CTBValueRestartOnChange = "restart-on-change"
+)
+
+// CTBMountEnabled returns true if the annotation value signals that the
+// ClusterTrustBundle projected volume should be mounted.
+func CTBMountEnabled(annotations map[string]string) bool {
+	v, ok := annotations[AnnotationAddClusterTrustBundle]
+	if !ok {
+		return false
+	}
+	return v == CTBValueTrue || v == CTBValueRestartOnChange
+}
+
+// CTBRestartEnabled returns true if the annotation value signals that the
+// pod should be restarted when the CTB CA changes.
+func CTBRestartEnabled(annotations map[string]string) bool {
+	v, ok := annotations[AnnotationAddClusterTrustBundle]
+	if !ok {
+		return false
+	}
+	return v == CTBValueRestartOnChange
+}

--- a/pkg/api/v1/ctb_values_test.go
+++ b/pkg/api/v1/ctb_values_test.go
@@ -1,0 +1,47 @@
+package v1_test
+
+import (
+	"testing"
+
+	v1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCTBMountEnabled(t *testing.T) {
+	tcs := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{name: "absent", annotations: map[string]string{}, want: false},
+		{name: "true", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "true"}, want: true},
+		{name: "false", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "false"}, want: false},
+		{name: "restart-on-change", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "restart-on-change"}, want: true},
+		{name: "unknown value", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "garbage"}, want: false},
+		{name: "nil map", annotations: nil, want: false},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, v1.CTBMountEnabled(tc.annotations))
+		})
+	}
+}
+
+func TestCTBRestartEnabled(t *testing.T) {
+	tcs := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{name: "absent", annotations: map[string]string{}, want: false},
+		{name: "true", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "true"}, want: false},
+		{name: "false", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "false"}, want: false},
+		{name: "restart-on-change", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "restart-on-change"}, want: true},
+		{name: "nil map", annotations: nil, want: false},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, v1.CTBRestartEnabled(tc.annotations))
+		})
+	}
+}

--- a/pkg/api/v1/types_test.go
+++ b/pkg/api/v1/types_test.go
@@ -162,3 +162,33 @@ func TestConfig_ExpandAnnotationAll(t *testing.T) {
 		assert.Equal(t, in, cfg.ExpandAnnotationAll(in))
 	})
 }
+
+func TestConfig_ExpandAnnotationAll_PreservesCTBValues(t *testing.T) {
+	cfg := &v1.Config{
+		Overrides: map[string]string{"x": "y"},
+		AvailableFeatures: []string{
+			v1.AnnotationAlterImgRegistry,
+			v1.AnnotationSetPullSecret,
+			v1.AnnotationAddClusterTrustBundle,
+		},
+	}
+
+	t.Run("restart-on-change preserved over all expansion", func(t *testing.T) {
+		got := cfg.ExpandAnnotationAll(map[string]string{
+			v1.AnnotationAll:                "true",
+			v1.AnnotationAddClusterTrustBundle: "restart-on-change",
+		})
+		assert.Equal(t, "restart-on-change", got[v1.AnnotationAddClusterTrustBundle])
+		assert.Equal(t, "true", got[v1.AnnotationAlterImgRegistry])
+		assert.Equal(t, "true", got[v1.AnnotationSetPullSecret])
+	})
+
+	t.Run("false preserved over all expansion", func(t *testing.T) {
+		got := cfg.ExpandAnnotationAll(map[string]string{
+			v1.AnnotationAll:                "true",
+			v1.AnnotationAddClusterTrustBundle: "false",
+		})
+		assert.Equal(t, "false", got[v1.AnnotationAddClusterTrustBundle])
+		assert.Equal(t, "true", got[v1.AnnotationAlterImgRegistry])
+	})
+}


### PR DESCRIPTION
## Summary

PR1 of the CTB restart-on-change feature ([#178](https://github.com/kyma-project/rt-bootstrapper/issues/178)).

Extends `rt-cfg.kyma-project.io/add-cluster-trust-bundle` annotation to accept three values:

| Value | Behavior |
|-------|----------|
| `"false"` | Explicit opt-out — no CTB mount, even if namespace defaults enable it |
| `"true"` | Mount CTB projected volume (existing behavior, unchanged) |
| `"restart-on-change"` | Mount CTB projected volume (restart logic added in later PR) |

## Changes

- `pkg/api/v1/ctb_values.go` — constants + helper functions (`CTBMountEnabled`, `CTBRestartEnabled`, `CTBExplicitOptOut`)
- `internal/webhook/v1/pod_defaulters.go` — CTB defaulter now uses multi-value check with explicit opt-out
- Tests for all new behavior including opt-out overriding namespace defaults

## Testing

All unit tests pass. No regressions in existing behavior.

Relates to #178