### PR TITLE
feat: CTB hash stamping + watcher

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,6 +49,7 @@ import (
 
 	//"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	"github.com/kyma-project/rt-bootstrapper/internal/controller"
 	webhook_v1 "github.com/kyma-project/rt-bootstrapper/internal/webhook/v1"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
@@ -276,12 +277,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	hashHolder := ctb.NewHashHolder()
+
 	whOpts := webhook_v1.SetupPodWebhookWithManagerOpts{
 		AvailableFeatures:        cfg.AvailableFeatures,
 		NamespaceDefaultFeatures: cfg.NamespaceDefaultFeatures,
 		GetConfig:                readConfig,
 		ImagePullSecretName:      imagePullSecretName,
 		Landscape:                landscape,
+		HashHolder:               hashHolder,
 	}
 
 	if err := webhook_v1.SetupPodWebhookWithManager(mgr, whOpts); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
 
 	"github.com/kyma-project/rt-bootstrapper/internal/webhook/certificate"
 	"k8s.io/client-go/util/retry"
@@ -71,6 +72,7 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(certificatesv1alpha1.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme
 }
@@ -279,6 +281,13 @@ func main() {
 
 	hashHolder := ctb.NewHashHolder()
 
+	if cfg.ClusterTrustBundleMapping != nil && slices.Contains(cfg.AvailableFeatures, apiv1.AnnotationAddClusterTrustBundle) {
+		if err := ctb.PreComputeHash(context.Background(), rtClient, cfg.ClusterTrustBundleMapping.Name, hashHolder); err != nil {
+			setupLog.Error(err, "failed to pre-compute CTB hash (CTB may not exist yet)")
+			// ponytail: non-fatal — hash stays empty until CTB appears and watcher fires
+		}
+	}
+
 	whOpts := webhook_v1.SetupPodWebhookWithManagerOpts{
 		AvailableFeatures:        cfg.AvailableFeatures,
 		NamespaceDefaultFeatures: cfg.NamespaceDefaultFeatures,
@@ -291,6 +300,18 @@ func main() {
 	if err := webhook_v1.SetupPodWebhookWithManager(mgr, whOpts); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Pod")
 		os.Exit(1)
+	}
+
+	if cfg.ClusterTrustBundleMapping != nil && slices.Contains(cfg.AvailableFeatures, apiv1.AnnotationAddClusterTrustBundle) {
+		if err := (&ctb.CTBWatcher{
+			Client:     mgr.GetClient(),
+			Scheme:     mgr.GetScheme(),
+			CTBName:    cfg.ClusterTrustBundleMapping.Name,
+			HashHolder: hashHolder,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "CTBWatcher")
+			os.Exit(1)
+		}
 	}
 
 	if err := (&controller.SecretReconciler{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,8 +28,8 @@ import (
 	"slices"
 	"time"
 
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
 
 	"github.com/kyma-project/rt-bootstrapper/internal/webhook/certificate"
 	"k8s.io/client-go/util/retry"
@@ -50,8 +50,8 @@ import (
 
 	//"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	"github.com/kyma-project/rt-bootstrapper/internal/controller"
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	webhook_v1 "github.com/kyma-project/rt-bootstrapper/internal/webhook/v1"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
 	// +kubebuilder:scaffold:imports
@@ -72,7 +72,7 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(certificatesv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(certificatesv1beta1.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -30,3 +30,11 @@ rules:
   verbs:
   - get
   - patch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - clustertrustbundles
+  verbs:
+  - get
+  - list
+  - watch

--- a/internal/ctb/hash_holder.go
+++ b/internal/ctb/hash_holder.go
@@ -1,0 +1,36 @@
+package ctb
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+)
+
+// HashHolder stores the current CTB hash in a thread-safe manner.
+// Shared between the webhook (reads) and the CTB watcher (writes).
+type HashHolder struct {
+	mu   sync.RWMutex
+	hash string
+}
+
+func NewHashHolder() *HashHolder {
+	return &HashHolder{}
+}
+
+func (h *HashHolder) Get() string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.hash
+}
+
+func (h *HashHolder) Set(hash string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.hash = hash
+}
+
+// ComputeAndSet hashes the given trust bundle content with SHA-256 and stores the result.
+func (h *HashHolder) ComputeAndSet(trustBundle string) {
+	sum := sha256.Sum256([]byte(trustBundle))
+	h.Set(hex.EncodeToString(sum[:]))
+}

--- a/internal/ctb/hash_holder_test.go
+++ b/internal/ctb/hash_holder_test.go
@@ -1,0 +1,45 @@
+package ctb_test
+
+import (
+	"testing"
+
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashHolder_GetSet(t *testing.T) {
+	h := ctb.NewHashHolder()
+	assert.Equal(t, "", h.Get())
+
+	h.Set("abc123")
+	assert.Equal(t, "abc123", h.Get())
+}
+
+func TestHashHolder_ComputeAndSet(t *testing.T) {
+	h := ctb.NewHashHolder()
+	h.ComputeAndSet("hello")
+	// SHA-256 of "hello"
+	assert.Equal(t, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", h.Get())
+}
+
+func TestHashHolder_ComputeAndSet_Empty(t *testing.T) {
+	h := ctb.NewHashHolder()
+	h.ComputeAndSet("")
+	// SHA-256 of ""
+	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", h.Get())
+}
+
+func TestHashHolder_ConcurrentAccess(t *testing.T) {
+	h := ctb.NewHashHolder()
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			h.Set("value")
+		}
+		close(done)
+	}()
+	for i := 0; i < 1000; i++ {
+		_ = h.Get()
+	}
+	<-done
+}

--- a/internal/ctb/watcher.go
+++ b/internal/ctb/watcher.go
@@ -1,0 +1,68 @@
+package ctb
+
+import (
+	"context"
+	"log/slog"
+
+	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// +kubebuilder:rbac:groups="certificates.k8s.io",resources=clustertrustbundles,verbs=get;list;watch
+
+// CTBWatcher watches a named ClusterTrustBundle and updates the hash holder on changes.
+type CTBWatcher struct {
+	client.Client
+	Scheme     *runtime.Scheme
+	CTBName    string
+	HashHolder *HashHolder
+}
+
+func (w *CTBWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if req.Name != w.CTBName {
+		return ctrl.Result{}, nil
+	}
+
+	log := slog.Default().With("controller", "ctb-watcher", "ctb-name", req.Name)
+
+	var ctb certificatesv1alpha1.ClusterTrustBundle
+	if err := w.Get(ctx, req.NamespacedName, &ctb); err != nil {
+		log.Error("failed to get ClusterTrustBundle", "error", err)
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	oldHash := w.HashHolder.Get()
+	w.HashHolder.ComputeAndSet(ctb.Spec.TrustBundle)
+	newHash := w.HashHolder.Get()
+
+	if oldHash != newHash {
+		log.Info("CTB hash updated", "old", oldHash, "new", newHash)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (w *CTBWatcher) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&certificatesv1alpha1.ClusterTrustBundle{}).
+		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
+			return object.GetName() == w.CTBName
+		})).
+		Named("ctb-watcher").
+		Complete(w)
+}
+
+// PreComputeHash reads the named CTB and initializes the hash holder.
+// Called at startup before the manager starts.
+func PreComputeHash(ctx context.Context, c client.Client, ctbName string, holder *HashHolder) error {
+	var ctb certificatesv1alpha1.ClusterTrustBundle
+	if err := c.Get(ctx, client.ObjectKey{Name: ctbName}, &ctb); err != nil {
+		return err
+	}
+	holder.ComputeAndSet(ctb.Spec.TrustBundle)
+	slog.Info("CTB hash pre-computed", "ctb-name", ctbName, "hash", holder.Get())
+	return nil
+}

--- a/internal/ctb/watcher.go
+++ b/internal/ctb/watcher.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log/slog"
 
-	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,7 +28,7 @@ func (w *CTBWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	log := slog.Default().With("controller", "ctb-watcher", "ctb-name", req.Name)
 
-	var ctb certificatesv1alpha1.ClusterTrustBundle
+	var ctb certificatesv1beta1.ClusterTrustBundle
 	if err := w.Get(ctx, req.NamespacedName, &ctb); err != nil {
 		log.Error("failed to get ClusterTrustBundle", "error", err)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -47,7 +47,7 @@ func (w *CTBWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 func (w *CTBWatcher) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&certificatesv1alpha1.ClusterTrustBundle{}).
+		For(&certificatesv1beta1.ClusterTrustBundle{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == w.CTBName
 		})).
@@ -58,7 +58,7 @@ func (w *CTBWatcher) SetupWithManager(mgr ctrl.Manager) error {
 // PreComputeHash reads the named CTB and initializes the hash holder.
 // Called at startup before the manager starts.
 func PreComputeHash(ctx context.Context, c client.Client, ctbName string, holder *HashHolder) error {
-	var ctb certificatesv1alpha1.ClusterTrustBundle
+	var ctb certificatesv1beta1.ClusterTrustBundle
 	if err := c.Get(ctx, client.ObjectKey{Name: ctbName}, &ctb); err != nil {
 		return err
 	}

--- a/internal/ctb/watcher_test.go
+++ b/internal/ctb/watcher_test.go
@@ -1,0 +1,119 @@
+package ctb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, certificatesv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestCTBWatcher_Reconcile(t *testing.T) {
+	s := newScheme(t)
+	ctbObj := &certificatesv1alpha1.ClusterTrustBundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
+		Spec:       certificatesv1alpha1.ClusterTrustBundleSpec{TrustBundle: "bundle-content"},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj).Build()
+	holder := ctb.NewHashHolder()
+
+	watcher := &ctb.CTBWatcher{
+		Client:     fakeClient,
+		Scheme:     s,
+		CTBName:    "my-ctb",
+		HashHolder: holder,
+	}
+
+	_, err := watcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "my-ctb"}})
+	require.NoError(t, err)
+	assert.NotEmpty(t, holder.Get())
+}
+
+func TestCTBWatcher_Reconcile_IgnoresOtherCTBs(t *testing.T) {
+	s := newScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+	holder := ctb.NewHashHolder()
+
+	watcher := &ctb.CTBWatcher{
+		Client:     fakeClient,
+		Scheme:     s,
+		CTBName:    "my-ctb",
+		HashHolder: holder,
+	}
+
+	_, err := watcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "other-ctb"}})
+	require.NoError(t, err)
+	assert.Empty(t, holder.Get())
+}
+
+func TestCTBWatcher_Reconcile_HashChangesOnUpdate(t *testing.T) {
+	s := newScheme(t)
+	ctbObj := &certificatesv1alpha1.ClusterTrustBundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
+		Spec:       certificatesv1alpha1.ClusterTrustBundleSpec{TrustBundle: "v1"},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj).Build()
+	holder := ctb.NewHashHolder()
+
+	watcher := &ctb.CTBWatcher{
+		Client:     fakeClient,
+		Scheme:     s,
+		CTBName:    "my-ctb",
+		HashHolder: holder,
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "my-ctb"}}
+	_, err := watcher.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	hash1 := holder.Get()
+
+	// Simulate content change
+	ctbObj.Spec.TrustBundle = "v2"
+	require.NoError(t, fakeClient.Update(context.Background(), ctbObj))
+
+	_, err = watcher.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	hash2 := holder.Get()
+
+	assert.NotEqual(t, hash1, hash2)
+}
+
+func TestPreComputeHash(t *testing.T) {
+	s := newScheme(t)
+	ctbObj := &certificatesv1alpha1.ClusterTrustBundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
+		Spec:       certificatesv1alpha1.ClusterTrustBundleSpec{TrustBundle: "test-bundle"},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj).Build()
+	holder := ctb.NewHashHolder()
+
+	require.NoError(t, ctb.PreComputeHash(context.Background(), fakeClient, "my-ctb", holder))
+	assert.NotEmpty(t, holder.Get())
+}
+
+func TestPreComputeHash_NotFound(t *testing.T) {
+	s := newScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+	holder := ctb.NewHashHolder()
+
+	err := ctb.PreComputeHash(context.Background(), fakeClient, "missing-ctb", holder)
+	require.Error(t, err)
+	assert.Empty(t, holder.Get())
+}

--- a/internal/ctb/watcher_test.go
+++ b/internal/ctb/watcher_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,15 +18,15 @@ import (
 func newScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
-	require.NoError(t, certificatesv1alpha1.AddToScheme(s))
+	require.NoError(t, certificatesv1beta1.AddToScheme(s))
 	return s
 }
 
 func TestCTBWatcher_Reconcile(t *testing.T) {
 	s := newScheme(t)
-	ctbObj := &certificatesv1alpha1.ClusterTrustBundle{
+	ctbObj := &certificatesv1beta1.ClusterTrustBundle{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
-		Spec:       certificatesv1alpha1.ClusterTrustBundleSpec{TrustBundle: "bundle-content"},
+		Spec:       certificatesv1beta1.ClusterTrustBundleSpec{TrustBundle: "bundle-content"},
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj).Build()
@@ -63,9 +63,9 @@ func TestCTBWatcher_Reconcile_IgnoresOtherCTBs(t *testing.T) {
 
 func TestCTBWatcher_Reconcile_HashChangesOnUpdate(t *testing.T) {
 	s := newScheme(t)
-	ctbObj := &certificatesv1alpha1.ClusterTrustBundle{
+	ctbObj := &certificatesv1beta1.ClusterTrustBundle{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
-		Spec:       certificatesv1alpha1.ClusterTrustBundleSpec{TrustBundle: "v1"},
+		Spec:       certificatesv1beta1.ClusterTrustBundleSpec{TrustBundle: "v1"},
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj).Build()
@@ -96,9 +96,9 @@ func TestCTBWatcher_Reconcile_HashChangesOnUpdate(t *testing.T) {
 
 func TestPreComputeHash(t *testing.T) {
 	s := newScheme(t)
-	ctbObj := &certificatesv1alpha1.ClusterTrustBundle{
+	ctbObj := &certificatesv1beta1.ClusterTrustBundle{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
-		Spec:       certificatesv1alpha1.ClusterTrustBundleSpec{TrustBundle: "test-bundle"},
+		Spec:       certificatesv1beta1.ClusterTrustBundleSpec{TrustBundle: "test-bundle"},
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj).Build()

--- a/internal/webhook/v1/pod_defaulters.go
+++ b/internal/webhook/v1/pod_defaulters.go
@@ -207,7 +207,9 @@ func BuildDefaulterAddClusterTrustBundle(hashHolder *ctb.HashHolder) PodDefaulte
 				modified := handleClusterTrustBundle(p, cfg)
 				// Stamp hash annotation if pod explicitly requested restart-on-change and hash is set
 				if apiv1.CTBRestartEnabled(p.Annotations) {
-					if hash := hashHolder.Get(); hash != "" {
+					if len(p.OwnerReferences) == 0 {
+						slog.Default().WithGroup("args").With(kvs...).Warn("orphan pod has restart-on-change but no owner, treating as 'true'")
+					} else if hash := hashHolder.Get(); hash != "" {
 						if p.Annotations == nil {
 							p.Annotations = map[string]string{}
 						}

--- a/internal/webhook/v1/pod_defaulters.go
+++ b/internal/webhook/v1/pod_defaulters.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"slices"
 
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	"github.com/kyma-project/rt-bootstrapper/internal/webhook/k8s"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -115,7 +116,7 @@ func BuildPodDefaulterAddImagePullSecrets(secretName string) PodDefaulter {
 	})
 }
 
-func BuildDefaulterAddClusterTrustBundle() PodDefaulter {
+func BuildDefaulterAddClusterTrustBundle(hashHolder *ctb.HashHolder) PodDefaulter {
 	// slog.Debug("building volume", mapping.KeysAndValues()...)
 
 	handleVolumeMount := func(cs []corev1.Container, m *k8s.ClusterTrustBundle) bool {
@@ -203,7 +204,18 @@ func BuildDefaulterAddClusterTrustBundle() PodDefaulter {
 		for _, annotations := range []map[string]string{defaultFeatures, expandedNamespaceAnnotations, expandedPodAnnotations} {
 			if apiv1.CTBMountEnabled(annotations) || k8s.Contains(annotations, annotationAddClusterTrustBundle) {
 				slog.Default().WithGroup("args").With(kvs...).Debug("CTB pod defaulting opt in")
-				return handleClusterTrustBundle(p, cfg), nil
+				modified := handleClusterTrustBundle(p, cfg)
+				// Stamp hash annotation if pod explicitly requested restart-on-change and hash is set
+				if apiv1.CTBRestartEnabled(p.Annotations) {
+					if hash := hashHolder.Get(); hash != "" {
+						if p.Annotations == nil {
+							p.Annotations = map[string]string{}
+						}
+						p.Annotations[apiv1.AnnotationCTBHash] = hash
+						modified = true
+					}
+				}
+				return modified, nil
 			}
 		}
 

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -35,6 +36,7 @@ type SetupPodWebhookWithManagerOpts struct {
 	NamespaceDefaultFeatures func(string) map[string]string
 	ImagePullSecretName      string
 	Landscape                string
+	HashHolder               *ctb.HashHolder
 	GetConfig
 }
 
@@ -48,7 +50,7 @@ func SetupPodWebhookWithManager(mgr ctrl.Manager, opts SetupPodWebhookWithManage
 	defaulterEntries := []defaulterEntry{
 		{annotation: apiv1.AnnotationAlterImgRegistry, defaulter: BuildPodDefaulterAlterImgRegistry()},
 		{annotation: apiv1.AnnotationSetPullSecret, defaulter: BuildPodDefaulterAddImagePullSecrets(opts.ImagePullSecretName)},
-		{annotation: apiv1.AnnotationAddClusterTrustBundle, defaulter: BuildDefaulterAddClusterTrustBundle()},
+		{annotation: apiv1.AnnotationAddClusterTrustBundle, defaulter: BuildDefaulterAddClusterTrustBundle(opts.HashHolder)},
 		{annotation: apiv1.AnnotationSetFipsMode, defaulter: BuildDefaulterFipsMode()},
 		{annotation: apiv1.AnnotationSetLandscape, defaulter: BuildDefaulterSetLandscape(opts.Landscape)},
 	}

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -310,10 +310,23 @@ var _ = Describe("Pod Webhook", func() {
 			pod := getTestPod(map[string]string{
 				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
 			})
+			pod.OwnerReferences = []metav1.OwnerReference{{Name: "rs", Kind: "ReplicaSet", APIVersion: "apps/v1", UID: "uid1"}}
 
 			err := defaulterCTB.Default(ctx, pod)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(pod.Annotations[apiv1.AnnotationCTBHash]).Should(Equal("abc123"))
+		})
+
+		It("Should NOT stamp hash on orphan pod with 'restart-on-change'", func() {
+			hashHolder.Set("abc123")
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+			})
+			// No OwnerReferences — orphan pod
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Annotations).ShouldNot(HaveKey(apiv1.AnnotationCTBHash))
 		})
 
 		It("Should NOT stamp hash annotation when annotation is 'true'", func() {

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	"github.com/kyma-project/rt-bootstrapper/internal/webhook/k8s"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -218,7 +219,8 @@ var _ = Describe("Pod Webhook", func() {
 			},
 		}
 
-		d3 := BuildDefaulterAddClusterTrustBundle()
+		hashHolder := ctb.NewHashHolder()
+		d3 := BuildDefaulterAddClusterTrustBundle(hashHolder)
 
 		defaulterCTB := podCustomDefaulter{
 			availableFeatures: []string{
@@ -283,7 +285,7 @@ var _ = Describe("Pod Webhook", func() {
 				availableFeatures: []string{
 					apiv1.AnnotationAddClusterTrustBundle,
 				},
-				defaulters: []PodDefaulter{BuildDefaulterAddClusterTrustBundle()},
+				defaulters: []PodDefaulter{BuildDefaulterAddClusterTrustBundle(ctb.NewHashHolder())},
 				GetNsAnnotations: func(_ context.Context, name string) (map[string]string, error) {
 					return nil, nil
 				},
@@ -302,7 +304,40 @@ var _ = Describe("Pod Webhook", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(pod.Spec.Volumes).Should(BeEmpty())
 		})
-	})
+
+		It("Should stamp hash annotation when 'restart-on-change' and hash is set", func() {
+			hashHolder.Set("abc123")
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+			})
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Annotations[apiv1.AnnotationCTBHash]).Should(Equal("abc123"))
+		})
+
+		It("Should NOT stamp hash annotation when annotation is 'true'", func() {
+			hashHolder.Set("abc123")
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "true",
+			})
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Annotations).ShouldNot(HaveKey(apiv1.AnnotationCTBHash))
+		})
+
+		It("Should NOT stamp hash annotation when hash is empty", func() {
+			hashHolder.Set("")
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+			})
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Annotations).ShouldNot(HaveKey(apiv1.AnnotationCTBHash))
+		})
+	}) // end Context("ClusterTrustBundle annotation values")
 
 	Context("When creating Pod under Defaulting Webhook", func() {
 		It("Should inject landscape env var", func() {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -21,6 +21,7 @@ const (
 	AnnotationSetLandscape          = "rt-cfg.kyma-project.io/set-landscape"
 	AnnotationAll                   = "rt-cfg.kyma-project.io/all"
 	AnnotationModified              = "rt-bootstrapper.kyma-project.io/modified"
+	AnnotationCTBHash               = "rt-bootstrapper.kyma-project.io/ctb-hash"
 	FiledManager                    = "rt-bootstrapper"
 	EnvKymaFipsModeEnabled          = "KYMA_FIPS_MODE_ENABLED"
 	EnvFipsModeEnabled              = "FIPS_MODE_ENABLED"


### PR DESCRIPTION
## Summary

PR2 of the CTB restart-on-change feature ([#178](https://github.com/kyma-project/rt-bootstrapper/issues/178)).

Adds hash-based tracking for CTB content changes:

1. **HashHolder** (`internal/ctb/hash_holder.go`) — thread-safe in-memory store shared between webhook and controller
2. **Webhook stamps hash** — pods with `"restart-on-change"` get `rt-bootstrapper.kyma-project.io/ctb-hash` annotation with SHA-256 of the CTB content
3. **CTB Watcher** (`internal/ctb/watcher.go`) — controller-runtime controller watching the named ClusterTrustBundle, updates hash on change
4. **Startup pre-computation** — hash computed before manager starts (eliminates race condition)

## Key Behaviors

- Only pods with `"restart-on-change"` get the hash annotation
- Pods with `"true"` are NOT stamped (backward compatible)
- Empty hash = don't stamp (safety for when CTB doesn't exist yet)
- CTB watcher only watches the configured CTB name (predicate filter)
- PreComputeHash failure is non-fatal (logged, hash stays empty)

## Depends On

- #190 (PR1: annotation value support)

Relates to #178