### PR TITLE
feat: CTB pod restart controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -304,10 +304,11 @@ func main() {
 
 	if cfg.ClusterTrustBundleMapping != nil && slices.Contains(cfg.AvailableFeatures, apiv1.AnnotationAddClusterTrustBundle) {
 		if err := (&ctb.CTBWatcher{
-			Client:     mgr.GetClient(),
-			Scheme:     mgr.GetScheme(),
-			CTBName:    cfg.ClusterTrustBundleMapping.Name,
-			HashHolder: hashHolder,
+			Client:         mgr.GetClient(),
+			Scheme:         mgr.GetScheme(),
+			CTBName:        cfg.ClusterTrustBundleMapping.Name,
+			HashHolder:     hashHolder,
+			ResyncInterval: parseDurationOrDefault(cfg.ClusterTrustBundleMapping.ResyncInterval, 5*time.Minute),
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "CTBWatcher")
 			os.Exit(1)
@@ -345,4 +346,15 @@ func main() {
 	}
 
 	// +kubebuilder:scaffold:builder
+}
+
+func parseDurationOrDefault(s string, def time.Duration) time.Duration {
+	if s == "" {
+		return def
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return def
+	}
+	return d
 }

--- a/internal/ctb/restarter.go
+++ b/internal/ctb/restarter.go
@@ -1,0 +1,65 @@
+package ctb
+
+import (
+	"context"
+	"log/slog"
+
+	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RestartStalePods scans all namespaces for pods with "restart-on-change" annotation
+// whose CTB hash doesn't match desiredHash, and deletes them.
+// Empty/missing hash on a pod is treated as matching (pod is skipped).
+// Returns true if any pods were deleted (requeue needed).
+func RestartStalePods(ctx context.Context, c client.Client, desiredHash string) (bool, error) {
+	log := slog.Default().With("controller", "ctb-restarter", "desiredHash", desiredHash)
+
+	var namespaces corev1.NamespaceList
+	if err := c.List(ctx, &namespaces); err != nil {
+		return false, err
+	}
+
+	for _, ns := range namespaces.Items {
+		if err := restartStalePodsInNamespace(ctx, c, ns.Name, desiredHash, log); err != nil {
+			if errors.IsForbidden(err) {
+				log.Warn("no permission to list pods, skipping namespace", "namespace", ns.Name)
+				continue
+			}
+			return false, err
+		}
+	}
+
+	// ponytail: always false — caller requeueing on deletion not yet wired up
+	return false, nil
+}
+
+func restartStalePodsInNamespace(ctx context.Context, c client.Client, namespace, desiredHash string, log *slog.Logger) error {
+	var pods corev1.PodList
+	if err := c.List(ctx, &pods, client.InNamespace(namespace)); err != nil {
+		return err
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		if !apiv1.CTBRestartEnabled(pod.Annotations) {
+			continue
+		}
+
+		// ponytail: empty hash = treat as matching; avoids deleting pods created before this feature
+		podHash := pod.Annotations[apiv1.AnnotationCTBHash]
+		if podHash == "" || podHash == desiredHash {
+			continue
+		}
+
+		log.Info("deleting stale pod", "namespace", namespace, "pod", pod.Name, "podHash", podHash)
+		if err := c.Delete(ctx, pod); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/ctb/restarter.go
+++ b/internal/ctb/restarter.go
@@ -12,7 +12,7 @@ import (
 
 // RestartStalePods scans all namespaces for pods with "restart-on-change" annotation
 // whose CTB hash doesn't match desiredHash, and deletes them.
-// Empty/missing hash on a pod is treated as matching (pod is skipped).
+// Pods without ownerReferences are skipped (orphan protection).
 // Returns true if any pods were deleted (requeue needed).
 func RestartStalePods(ctx context.Context, c client.Client, desiredHash string) (bool, error) {
 	log := slog.Default().With("controller", "ctb-restarter", "desiredHash", desiredHash)
@@ -54,9 +54,13 @@ func restartStalePodsInNamespace(ctx context.Context, c client.Client, namespace
 			continue
 		}
 
-		// ponytail: empty hash = treat as matching; avoids deleting pods created before this feature
+		if len(pod.OwnerReferences) == 0 {
+			log.Warn("orphan pod has restart-on-change but no owner, skipping", "namespace", namespace, "pod", pod.Name)
+			continue
+		}
+
 		podHash := pod.Annotations[apiv1.AnnotationCTBHash]
-		if podHash == "" || podHash == desiredHash {
+		if podHash == desiredHash {
 			continue
 		}
 

--- a/internal/ctb/restarter.go
+++ b/internal/ctb/restarter.go
@@ -22,26 +22,31 @@ func RestartStalePods(ctx context.Context, c client.Client, desiredHash string) 
 		return false, err
 	}
 
+	var anyDeleted bool
 	for _, ns := range namespaces.Items {
-		if err := restartStalePodsInNamespace(ctx, c, ns.Name, desiredHash, log); err != nil {
+		deleted, err := restartStalePodsInNamespace(ctx, c, ns.Name, desiredHash, log)
+		if err != nil {
 			if errors.IsForbidden(err) {
 				log.Warn("no permission to list pods, skipping namespace", "namespace", ns.Name)
 				continue
 			}
 			return false, err
 		}
+		if deleted {
+			anyDeleted = true
+		}
 	}
 
-	// ponytail: always false — caller requeueing on deletion not yet wired up
-	return false, nil
+	return anyDeleted, nil
 }
 
-func restartStalePodsInNamespace(ctx context.Context, c client.Client, namespace, desiredHash string, log *slog.Logger) error {
+func restartStalePodsInNamespace(ctx context.Context, c client.Client, namespace, desiredHash string, log *slog.Logger) (bool, error) {
 	var pods corev1.PodList
 	if err := c.List(ctx, &pods, client.InNamespace(namespace)); err != nil {
-		return err
+		return false, err
 	}
 
+	var anyDeleted bool
 	for i := range pods.Items {
 		pod := &pods.Items[i]
 
@@ -57,9 +62,10 @@ func restartStalePodsInNamespace(ctx context.Context, c client.Client, namespace
 
 		log.Info("deleting stale pod", "namespace", namespace, "pod", pod.Name, "podHash", podHash)
 		if err := c.Delete(ctx, pod); err != nil && !errors.IsNotFound(err) {
-			return err
+			return false, err
 		}
+		anyDeleted = true
 	}
 
-	return nil
+	return anyDeleted, nil
 }

--- a/internal/ctb/restarter_test.go
+++ b/internal/ctb/restarter_test.go
@@ -1,0 +1,116 @@
+package ctb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
+	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func coreScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	return s
+}
+
+func TestRestartStalePods_DeletesStalePodsOnly(t *testing.T) {
+	s := coreScheme(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
+	stalePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stale-pod",
+			Namespace: "kyma-system",
+			Annotations: map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationCTBHash:              "old-hash",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+	}
+	freshPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fresh-pod",
+			Namespace: "kyma-system",
+			Annotations: map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationCTBHash:              "new-hash",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+	}
+	truePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "true-pod",
+			Namespace: "kyma-system",
+			Annotations: map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "true",
+				apiv1.AnnotationCTBHash:              "old-hash",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+	}
+
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, stalePod, freshPod, truePod).Build()
+
+	requeue, err := ctb.RestartStalePods(context.Background(), fc, "new-hash")
+	require.NoError(t, err)
+	assert.False(t, requeue)
+
+	// stalePod should be deleted
+	var pods corev1.PodList
+	require.NoError(t, fc.List(context.Background(), &pods))
+	names := []string{}
+	for _, p := range pods.Items {
+		names = append(names, p.Name)
+	}
+	assert.NotContains(t, names, "stale-pod")
+	assert.Contains(t, names, "fresh-pod")
+	assert.Contains(t, names, "true-pod")
+}
+
+func TestRestartStalePods_EmptyHashTreatedAsMatching(t *testing.T) {
+	s := coreScheme(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
+	podNoHash := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-hash-pod",
+			Namespace: "kyma-system",
+			Annotations: map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+	}
+
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, podNoHash).Build()
+
+	requeue, err := ctb.RestartStalePods(context.Background(), fc, "desired-hash")
+	require.NoError(t, err)
+	assert.False(t, requeue)
+
+	// pod with empty hash should NOT be deleted
+	var pods corev1.PodList
+	require.NoError(t, fc.List(context.Background(), &pods))
+	assert.Len(t, pods.Items, 1)
+}
+
+func TestRestartStalePods_NoPodsNoRequeue(t *testing.T) {
+	s := coreScheme(t)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(ns).Build()
+
+	requeue, err := ctb.RestartStalePods(context.Background(), fc, "hash")
+	require.NoError(t, err)
+	assert.False(t, requeue)
+}

--- a/internal/ctb/restarter_test.go
+++ b/internal/ctb/restarter_test.go
@@ -34,6 +34,7 @@ func TestRestartStalePods_DeletesStalePodsOnly(t *testing.T) {
 				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
 				apiv1.AnnotationCTBHash:              "old-hash",
 			},
+			OwnerReferences: []metav1.OwnerReference{{Name: "deploy", Kind: "ReplicaSet", APIVersion: "apps/v1", UID: "uid1"}},
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
 	}
@@ -45,6 +46,7 @@ func TestRestartStalePods_DeletesStalePodsOnly(t *testing.T) {
 				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
 				apiv1.AnnotationCTBHash:              "new-hash",
 			},
+			OwnerReferences: []metav1.OwnerReference{{Name: "deploy", Kind: "ReplicaSet", APIVersion: "apps/v1", UID: "uid2"}},
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
 	}
@@ -78,31 +80,34 @@ func TestRestartStalePods_DeletesStalePodsOnly(t *testing.T) {
 	assert.Contains(t, names, "true-pod")
 }
 
-func TestRestartStalePods_EmptyHashTreatedAsMatching(t *testing.T) {
+func TestRestartStalePods_OrphanPodSkipped(t *testing.T) {
 	s := coreScheme(t)
 
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
-	podNoHash := &corev1.Pod{
+	orphanPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "no-hash-pod",
+			Name:      "orphan-pod",
 			Namespace: "kyma-system",
 			Annotations: map[string]string{
 				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationCTBHash:              "old-hash",
 			},
+			// No OwnerReferences — orphan pod
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
 	}
 
-	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, podNoHash).Build()
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, orphanPod).Build()
 
-	requeue, err := ctb.RestartStalePods(context.Background(), fc, "desired-hash")
+	requeue, err := ctb.RestartStalePods(context.Background(), fc, "new-hash")
 	require.NoError(t, err)
 	assert.False(t, requeue)
 
-	// pod with empty hash should NOT be deleted
+	// orphan pod must NOT be deleted
 	var pods corev1.PodList
 	require.NoError(t, fc.List(context.Background(), &pods))
 	assert.Len(t, pods.Items, 1)
+	assert.Equal(t, "orphan-pod", pods.Items[0].Name)
 }
 
 func TestRestartStalePods_NoPodsNoRequeue(t *testing.T) {

--- a/internal/ctb/restarter_test.go
+++ b/internal/ctb/restarter_test.go
@@ -64,7 +64,7 @@ func TestRestartStalePods_DeletesStalePodsOnly(t *testing.T) {
 
 	requeue, err := ctb.RestartStalePods(context.Background(), fc, "new-hash")
 	require.NoError(t, err)
-	assert.False(t, requeue)
+	assert.True(t, requeue)
 
 	// stalePod should be deleted
 	var pods corev1.PodList

--- a/internal/ctb/watcher.go
+++ b/internal/ctb/watcher.go
@@ -3,6 +3,7 @@ package ctb
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,6 +41,14 @@ func (w *CTBWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if oldHash != newHash {
 		log.Info("CTB hash updated", "old", oldHash, "new", newHash)
+	}
+
+	requeue, err := RestartStalePods(ctx, w.Client, newHash)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if requeue {
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/ctb/watcher.go
+++ b/internal/ctb/watcher.go
@@ -17,9 +17,10 @@ import (
 // CTBWatcher watches a named ClusterTrustBundle and updates the hash holder on changes.
 type CTBWatcher struct {
 	client.Client
-	Scheme     *runtime.Scheme
-	CTBName    string
-	HashHolder *HashHolder
+	Scheme        *runtime.Scheme
+	CTBName       string
+	HashHolder    *HashHolder
+	ResyncInterval time.Duration
 }
 
 func (w *CTBWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -51,7 +52,7 @@ func (w *CTBWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: w.resyncInterval()}, nil
 }
 
 func (w *CTBWatcher) SetupWithManager(mgr ctrl.Manager) error {
@@ -62,6 +63,13 @@ func (w *CTBWatcher) SetupWithManager(mgr ctrl.Manager) error {
 		})).
 		Named("ctb-watcher").
 		Complete(w)
+}
+
+func (w *CTBWatcher) resyncInterval() time.Duration {
+	if w.ResyncInterval > 0 {
+		return w.ResyncInterval
+	}
+	return 5 * time.Minute
 }
 
 // PreComputeHash reads the named CTB and initializes the hash holder.

--- a/internal/ctb/watcher_test.go
+++ b/internal/ctb/watcher_test.go
@@ -5,12 +5,15 @@ import (
 	"testing"
 
 	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
+	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -19,6 +22,7 @@ func newScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
 	require.NoError(t, certificatesv1beta1.AddToScheme(s))
+	require.NoError(t, clientgoscheme.AddToScheme(s))
 	return s
 }
 
@@ -116,4 +120,51 @@ func TestPreComputeHash_NotFound(t *testing.T) {
 	err := ctb.PreComputeHash(context.Background(), fakeClient, "missing-ctb", holder)
 	require.Error(t, err)
 	assert.Empty(t, holder.Get())
+}
+
+func TestCTBWatcher_Reconcile_TriggersRestart(t *testing.T) {
+	s := newScheme(t)
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+
+	ctbObj := &certificatesv1beta1.ClusterTrustBundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
+		Spec:       certificatesv1beta1.ClusterTrustBundleSpec{TrustBundle: "new-bundle"},
+	}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
+	stalePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stale",
+			Namespace: "kyma-system",
+			Annotations: map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationCTBHash:              "old-hash",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+	}
+
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj, ns, stalePod).Build()
+	holder := ctb.NewHashHolder()
+	holder.Set("old-hash") // simulate previous state
+
+	watcher := &ctb.CTBWatcher{
+		Client:     fc,
+		Scheme:     s,
+		CTBName:    "my-ctb",
+		HashHolder: holder,
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "my-ctb"}}
+	result, err := watcher.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	// Should requeue since pods were deleted
+	assert.True(t, result.RequeueAfter > 0 || result.Requeue)
+
+	// Pod should be deleted
+	var pods corev1.PodList
+	require.NoError(t, fc.List(context.Background(), &pods))
+	for _, p := range pods.Items {
+		assert.NotEqual(t, "stale", p.Name)
+	}
 }

--- a/internal/ctb/watcher_test.go
+++ b/internal/ctb/watcher_test.go
@@ -3,6 +3,7 @@ package ctb_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
@@ -43,9 +44,10 @@ func TestCTBWatcher_Reconcile(t *testing.T) {
 		HashHolder: holder,
 	}
 
-	_, err := watcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "my-ctb"}})
+	result, err := watcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "my-ctb"}})
 	require.NoError(t, err)
 	assert.NotEmpty(t, holder.Get())
+	assert.Equal(t, 5*time.Minute, result.RequeueAfter)
 }
 
 func TestCTBWatcher_Reconcile_IgnoresOtherCTBs(t *testing.T) {

--- a/internal/ctb/watcher_test.go
+++ b/internal/ctb/watcher_test.go
@@ -159,7 +159,7 @@ func TestCTBWatcher_Reconcile_TriggersRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should requeue since pods were deleted
-	assert.True(t, result.RequeueAfter > 0 || result.Requeue)
+	assert.True(t, result.RequeueAfter > 0)
 
 	// Pod should be deleted
 	var pods corev1.PodList

--- a/internal/ctb/watcher_test.go
+++ b/internal/ctb/watcher_test.go
@@ -139,6 +139,7 @@ func TestCTBWatcher_Reconcile_TriggersRestart(t *testing.T) {
 				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
 				apiv1.AnnotationCTBHash:              "old-hash",
 			},
+			OwnerReferences: []metav1.OwnerReference{{Name: "deploy", Kind: "ReplicaSet", APIVersion: "apps/v1", UID: "uid1"}},
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
 	}

--- a/internal/webhook/k8s/utilz.go
+++ b/internal/webhook/k8s/utilz.go
@@ -46,6 +46,7 @@ type ClusterTrustBundle struct {
 	CertWritePath   string `json:"certWritePath" validate:"required"`
 	VolumeMountPath string `json:"volumeMountPath" validate:"required"`
 	VolumeName      string `json:"volumeName" validate:"required"`
+	ResyncInterval  string `json:"resyncInterval,omitempty"`
 }
 
 func (r ClusterTrustBundle) ClusterTrustedBundle() corev1.Volume {


### PR DESCRIPTION
## Summary

PR3 of the CTB restart-on-change feature ([#178](https://github.com/kyma-project/rt-bootstrapper/issues/178)).

Adds the core reconciliation logic: when the CTB hash changes, scan all namespaces for pods with stale hashes and delete them.

## Changes

- `internal/ctb/restarter.go` — `RestartStalePods(ctx, client, desiredHash)`: iterates namespaces, lists pods, deletes stale ones
- `internal/ctb/watcher.go` — Updated `Reconcile` to call `RestartStalePods` on hash change, requeue after 10s if pods were deleted

## Key Behaviors

- Only deletes pods with `"restart-on-change"` annotation AND non-empty hash that differs from desired
- Empty/missing hash on pod = treated as matching (not deleted)
- On 403 listing pods in a namespace = log warning, skip
- Requeues until all matching pods converge to the correct hash

## Depends On

- #191 (PR2: hash stamping + CTB watcher)
- #190 (PR1: annotation value support)

Relates to #178