### PR TITLE
feat: RBAC for CTB pod restart in Kyma-managed namespaces

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -18,3 +18,5 @@ resources:
 - metrics_auth_role.yaml
 - metrics_auth_role_binding.yaml
 - metrics_reader_role.yaml
+- pod_restarter_role.yaml
+- pod_restarter_role_binding.yaml

--- a/config/rbac/pod_restarter_role.yaml
+++ b/config/rbac/pod_restarter_role.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: rt-bootstrapper
+    app.kubernetes.io/managed-by: kustomize
+  name: pod-restarter-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - delete

--- a/config/rbac/pod_restarter_role_binding.yaml
+++ b/config/rbac/pod_restarter_role_binding.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rt-bootstrapper
+    app.kubernetes.io/managed-by: kustomize
+  name: pod-restarter-rolebinding
+  namespace: kyma-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pod-restarter-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rt-bootstrapper
+    app.kubernetes.io/managed-by: kustomize
+  name: pod-restarter-rolebinding
+  namespace: istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pod-restarter-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/rbac/pod_restarter_role_binding.yaml
+++ b/config/rbac/pod_restarter_role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: rt-bootstrapper
     app.kubernetes.io/managed-by: kustomize
-  name: pod-restarter-rolebinding
+  name: pod-restarter-kyma-system
   namespace: kyma-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/name: rt-bootstrapper
     app.kubernetes.io/managed-by: kustomize
-  name: pod-restarter-rolebinding
+  name: pod-restarter-istio-system
   namespace: istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39,7 +39,7 @@ metadata:
   labels:
     app.kubernetes.io/name: rt-bootstrapper
     app.kubernetes.io/managed-by: kustomize
-  name: pod-restarter-rolebinding
+  name: pod-restarter-sap-transp-proxy-system
   namespace: sap-transp-proxy-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/pod_restarter_role_binding.yaml
+++ b/config/rbac/pod_restarter_role_binding.yaml
@@ -32,3 +32,20 @@ subjects:
 - kind: ServiceAccount
   name: controller-manager
   namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rt-bootstrapper
+    app.kubernetes.io/managed-by: kustomize
+  name: pod-restarter-rolebinding
+  namespace: sap-transp-proxy-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pod-restarter-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system


### PR DESCRIPTION
## Summary

PR4 of the CTB restart-on-change feature ([#178](https://github.com/kyma-project/rt-bootstrapper/issues/178)).

Adds RBAC permissions for the pod restart controller to list and delete pods in Kyma-managed namespaces.

## Changes

- `config/rbac/pod_restarter_role.yaml` — ClusterRole with `get`, `list`, `delete` on pods
- `config/rbac/pod_restarter_role_binding.yaml` — RoleBindings in `kyma-system`, `istio-system`, and `sap-transp-proxy-system`
- `config/rbac/kustomization.yaml` — references new files

## Design

- **ClusterRole** defines the permissions (what)
- **RoleBindings** in specific namespaces define the scope (where)
- No ClusterRoleBinding — RBAC is the namespace boundary
- Other Kyma component owners can extend by adding their own RoleBinding referencing `pod-restarter-role`

## Depends On

- #192 (PR3: CTB pod restart controller)

Relates to #178