### PR TITLE
feat: simplify CTB annotation to 'true'/'false' only (remove restart-on-change)

### DIFF
--- a/.pi/prompts/opsx-apply.md
+++ b/.pi/prompts/opsx-apply.md
@@ -1,0 +1,153 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name (e.g., `/opsx-apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+**Provided arguments**: $@
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx-apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx-continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx-archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.pi/prompts/opsx-archive.md
+++ b/.pi/prompts/opsx-archive.md
@@ -1,0 +1,158 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx-archive` (e.g., `/opsx-archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+**Provided arguments**: $@
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.pi/prompts/opsx-explore.md
+++ b/.pi/prompts/opsx-explore.md
@@ -1,0 +1,172 @@
+---
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx-explore` is whatever the user wants to think about. Could be:
+**Provided arguments**: $@
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.pi/prompts/opsx-propose.md
+++ b/.pi/prompts/opsx-propose.md
@@ -1,0 +1,107 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx-apply
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx-propose` is the change name (kebab-case), OR a description of what the user wants to build.
+**Provided arguments**: $@
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx-apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.pi/prompts/opsx-sync.md
+++ b/.pi/prompts/opsx-sync.md
@@ -1,0 +1,141 @@
+---
+description: Sync delta specs from a change to main specs
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx-sync` (e.g., `/opsx-sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+**Provided arguments**: $@
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.pi/prompts/opsx-update.md
+++ b/.pi/prompts/opsx-update.md
@@ -1,0 +1,79 @@
+---
+description: Update a change - revise existing planning artifacts and keep them coherent (Experimental)
+---
+
+Revise a change's existing planning artifacts and keep them coherent. Never edit code.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx-update` (e.g., `/opsx-update add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+**Provided arguments**: $@
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes sorted by most recently modified. Then use the **AskUserQuestion tool** to let the user select which change to update.
+
+   Present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to update.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Get the change's artifacts**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+   The artifact ids and paths come from the active schema - do NOT assume them, and do NOT branch on hardcoded artifact names. Custom schemas must work unchanged.
+
+   The files to edit are `artifactPaths.<id>.existingOutputPaths` - the concrete files that exist on disk, already glob-expanded for glob artifacts (e.g. `specs/**/*.md`). Do NOT write to `resolvedOutputPath`: for a glob artifact it is still the glob pattern, not a real file.
+
+3. **Understand the request**
+   - If the user asked for a specific revision ("the design now uses X"), that is the starting edit.
+   - If they only said "update" / "make this coherent", treat it as a coherence review: read the existing artifacts and check them against each other for contradictions, gaps, and duplication.
+
+4. **Read and reconcile**
+   - Read the artifact(s) the request touches and the change's other existing artifacts.
+   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Note everything that is now inconsistent, missing, or contradictory.
+   - Revise only files that already exist (`existingOutputPaths`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to `/opsx-continue` to create them.
+   - If the change is already coherent, say so and make no edits.
+
+5. **Confirm and apply, one artifact at a time**
+   - Show each proposed revision and why. Write only after the user confirms.
+   - If the user rejects a revision, do not write it - leave that artifact unchanged.
+   - When a substantial rewrite is needed, get that artifact's rules and template first:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+
+6. **Point to the next step (guidance only - NEVER act on it)**
+   - Artifacts still missing -> suggest `/opsx-continue` to create them.
+   - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest `/opsx-apply` to carry the delta into code.
+   - Everything done and implemented -> suggest `/opsx-archive`.
+
+**Output**
+
+After each invocation, show:
+- Which artifacts were revised (and which proposed revisions were rejected)
+- Anything deferred to `/opsx-continue` (not-yet-created artifacts or files)
+- Where the change stands and the recommended next command
+
+**Guardrails**
+- Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to `/opsx-apply`.
+- Use the artifact ids and paths reported by `openspec status`; never branch on hardcoded artifact names.
+- Edit only the concrete files in `existingOutputPaths`; never write to a glob `resolvedOutputPath`.
+- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is `/opsx-continue`'s job.
+- Confirm every edit with the user before writing.
+- If the request changes the change's *intent* rather than refining it, recommend starting fresh with `/opsx-new` (the "Update vs. Start Fresh" heuristic).

--- a/.pi/skills/openspec-apply-change/SKILL.md
+++ b/.pi/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx-apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.pi/skills/openspec-archive-change/SKILL.md
+++ b/.pi/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.pi/skills/openspec-explore/SKILL.md
+++ b/.pi/skills/openspec-explore/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx-explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.pi/skills/openspec-propose/SKILL.md
+++ b/.pi/skills/openspec-propose/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx-apply
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx-apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.pi/skills/openspec-sync-specs/SKILL.md
+++ b/.pi/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.pi/skills/openspec-update-change/SKILL.md
+++ b/.pi/skills/openspec-update-change/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: openspec-update-change
+description: Update an OpenSpec change by revising its existing planning artifacts and keeping them coherent with one another. Use when the user wants to revise a change's plan, fold new decisions into it, or reconcile its artifacts after an edit. Never edits code.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Revise a change's existing planning artifacts and keep them coherent. Never edit code.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes sorted by most recently modified. Then use the **AskUserQuestion tool** to let the user select which change to update.
+
+   Present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to update.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Get the change's artifacts**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+   The artifact ids and paths come from the active schema - do NOT assume them, and do NOT branch on hardcoded artifact names. Custom schemas must work unchanged.
+
+   The files to edit are `artifactPaths.<id>.existingOutputPaths` - the concrete files that exist on disk, already glob-expanded for glob artifacts (e.g. `specs/**/*.md`). Do NOT write to `resolvedOutputPath`: for a glob artifact it is still the glob pattern, not a real file.
+
+3. **Understand the request**
+   - If the user asked for a specific revision ("the design now uses X"), that is the starting edit.
+   - If they only said "update" / "make this coherent", treat it as a coherence review: read the existing artifacts and check them against each other for contradictions, gaps, and duplication.
+
+4. **Read and reconcile**
+   - Read the artifact(s) the request touches and the change's other existing artifacts.
+   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Note everything that is now inconsistent, missing, or contradictory.
+   - Revise only files that already exist (`existingOutputPaths`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to `/opsx-continue` to create them.
+   - If the change is already coherent, say so and make no edits.
+
+5. **Confirm and apply, one artifact at a time**
+   - Show each proposed revision and why. Write only after the user confirms.
+   - If the user rejects a revision, do not write it - leave that artifact unchanged.
+   - When a substantial rewrite is needed, get that artifact's rules and template first:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+
+6. **Point to the next step (guidance only - NEVER act on it)**
+   - Artifacts still missing -> suggest `/opsx-continue` to create them.
+   - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest `/opsx-apply` to carry the delta into code.
+   - Everything done and implemented -> suggest `/opsx-archive`.
+
+**Output**
+
+After each invocation, show:
+- Which artifacts were revised (and which proposed revisions were rejected)
+- Anything deferred to `/opsx-continue` (not-yet-created artifacts or files)
+- Where the change stands and the recommended next command
+
+**Guardrails**
+- Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to `/opsx-apply`.
+- Use the artifact ids and paths reported by `openspec status`; never branch on hardcoded artifact names.
+- Edit only the concrete files in `existingOutputPaths`; never write to a glob `resolvedOutputPath`.
+- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is `/opsx-continue`'s job.
+- Confirm every edit with the user before writing.
+- If the request changes the change's *intent* rather than refining it, recommend starting fresh with `/opsx-new` (the "Update vs. Start Fresh" heuristic).

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -304,10 +304,11 @@ func main() {
 
 	if cfg.ClusterTrustBundleMapping != nil && slices.Contains(cfg.AvailableFeatures, apiv1.AnnotationAddClusterTrustBundle) {
 		if err := (&ctb.CTBWatcher{
-			Client:     mgr.GetClient(),
-			Scheme:     mgr.GetScheme(),
-			CTBName:    cfg.ClusterTrustBundleMapping.Name,
-			HashHolder: hashHolder,
+			Client:         mgr.GetClient(),
+			Scheme:         mgr.GetScheme(),
+			CTBName:        cfg.ClusterTrustBundleMapping.Name,
+			HashHolder:     hashHolder,
+			ResyncInterval: parseDurationOrDefault(cfg.ClusterTrustBundleMapping.ResyncInterval, 5*time.Minute),
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "CTBWatcher")
 			os.Exit(1)
@@ -345,4 +346,15 @@ func main() {
 	}
 
 	// +kubebuilder:scaffold:builder
+}
+
+func parseDurationOrDefault(s string, def time.Duration) time.Duration {
+	if s == "" {
+		return def
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return def
+	}
+	return d
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,6 +49,7 @@ import (
 
 	//"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	"github.com/kyma-project/rt-bootstrapper/internal/controller"
 	webhook_v1 "github.com/kyma-project/rt-bootstrapper/internal/webhook/v1"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
@@ -276,12 +277,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	hashHolder := ctb.NewHashHolder()
+
 	whOpts := webhook_v1.SetupPodWebhookWithManagerOpts{
 		AvailableFeatures:        cfg.AvailableFeatures,
 		NamespaceDefaultFeatures: cfg.NamespaceDefaultFeatures,
 		GetConfig:                readConfig,
 		ImagePullSecretName:      imagePullSecretName,
 		Landscape:                landscape,
+		HashHolder:               hashHolder,
 	}
 
 	if err := webhook_v1.SetupPodWebhookWithManager(mgr, whOpts); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
 
 	"github.com/kyma-project/rt-bootstrapper/internal/webhook/certificate"
 	"k8s.io/client-go/util/retry"
@@ -71,6 +72,7 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(certificatesv1alpha1.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme
 }
@@ -279,6 +281,13 @@ func main() {
 
 	hashHolder := ctb.NewHashHolder()
 
+	if cfg.ClusterTrustBundleMapping != nil && slices.Contains(cfg.AvailableFeatures, apiv1.AnnotationAddClusterTrustBundle) {
+		if err := ctb.PreComputeHash(context.Background(), rtClient, cfg.ClusterTrustBundleMapping.Name, hashHolder); err != nil {
+			setupLog.Error(err, "failed to pre-compute CTB hash (CTB may not exist yet)")
+			// ponytail: non-fatal — hash stays empty until CTB appears and watcher fires
+		}
+	}
+
 	whOpts := webhook_v1.SetupPodWebhookWithManagerOpts{
 		AvailableFeatures:        cfg.AvailableFeatures,
 		NamespaceDefaultFeatures: cfg.NamespaceDefaultFeatures,
@@ -291,6 +300,18 @@ func main() {
 	if err := webhook_v1.SetupPodWebhookWithManager(mgr, whOpts); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Pod")
 		os.Exit(1)
+	}
+
+	if cfg.ClusterTrustBundleMapping != nil && slices.Contains(cfg.AvailableFeatures, apiv1.AnnotationAddClusterTrustBundle) {
+		if err := (&ctb.CTBWatcher{
+			Client:     mgr.GetClient(),
+			Scheme:     mgr.GetScheme(),
+			CTBName:    cfg.ClusterTrustBundleMapping.Name,
+			HashHolder: hashHolder,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "CTBWatcher")
+			os.Exit(1)
+		}
 	}
 
 	if err := (&controller.SecretReconciler{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,8 +28,8 @@ import (
 	"slices"
 	"time"
 
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
 
 	"github.com/kyma-project/rt-bootstrapper/internal/webhook/certificate"
 	"k8s.io/client-go/util/retry"
@@ -50,8 +50,8 @@ import (
 
 	//"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	"github.com/kyma-project/rt-bootstrapper/internal/controller"
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	webhook_v1 "github.com/kyma-project/rt-bootstrapper/internal/webhook/v1"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
 	// +kubebuilder:scaffold:imports
@@ -72,7 +72,7 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(certificatesv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(certificatesv1beta1.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -30,3 +30,11 @@ rules:
   verbs:
   - get
   - patch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - clustertrustbundles
+  verbs:
+  - get
+  - list
+  - watch

--- a/internal/ctb/hash_holder.go
+++ b/internal/ctb/hash_holder.go
@@ -1,0 +1,36 @@
+package ctb
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+)
+
+// HashHolder stores the current CTB hash in a thread-safe manner.
+// Shared between the webhook (reads) and the CTB watcher (writes).
+type HashHolder struct {
+	mu   sync.RWMutex
+	hash string
+}
+
+func NewHashHolder() *HashHolder {
+	return &HashHolder{}
+}
+
+func (h *HashHolder) Get() string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.hash
+}
+
+func (h *HashHolder) Set(hash string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.hash = hash
+}
+
+// ComputeAndSet hashes the given trust bundle content with SHA-256 and stores the result.
+func (h *HashHolder) ComputeAndSet(trustBundle string) {
+	sum := sha256.Sum256([]byte(trustBundle))
+	h.Set(hex.EncodeToString(sum[:]))
+}

--- a/internal/ctb/hash_holder_test.go
+++ b/internal/ctb/hash_holder_test.go
@@ -1,0 +1,45 @@
+package ctb_test
+
+import (
+	"testing"
+
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashHolder_GetSet(t *testing.T) {
+	h := ctb.NewHashHolder()
+	assert.Equal(t, "", h.Get())
+
+	h.Set("abc123")
+	assert.Equal(t, "abc123", h.Get())
+}
+
+func TestHashHolder_ComputeAndSet(t *testing.T) {
+	h := ctb.NewHashHolder()
+	h.ComputeAndSet("hello")
+	// SHA-256 of "hello"
+	assert.Equal(t, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", h.Get())
+}
+
+func TestHashHolder_ComputeAndSet_Empty(t *testing.T) {
+	h := ctb.NewHashHolder()
+	h.ComputeAndSet("")
+	// SHA-256 of ""
+	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", h.Get())
+}
+
+func TestHashHolder_ConcurrentAccess(t *testing.T) {
+	h := ctb.NewHashHolder()
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			h.Set("value")
+		}
+		close(done)
+	}()
+	for i := 0; i < 1000; i++ {
+		_ = h.Get()
+	}
+	<-done
+}

--- a/internal/ctb/restarter.go
+++ b/internal/ctb/restarter.go
@@ -1,0 +1,65 @@
+package ctb
+
+import (
+	"context"
+	"log/slog"
+
+	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RestartStalePods scans all namespaces for pods with "restart-on-change" annotation
+// whose CTB hash doesn't match desiredHash, and deletes them.
+// Empty/missing hash on a pod is treated as matching (pod is skipped).
+// Returns true if any pods were deleted (requeue needed).
+func RestartStalePods(ctx context.Context, c client.Client, desiredHash string) (bool, error) {
+	log := slog.Default().With("controller", "ctb-restarter", "desiredHash", desiredHash)
+
+	var namespaces corev1.NamespaceList
+	if err := c.List(ctx, &namespaces); err != nil {
+		return false, err
+	}
+
+	for _, ns := range namespaces.Items {
+		if err := restartStalePodsInNamespace(ctx, c, ns.Name, desiredHash, log); err != nil {
+			if errors.IsForbidden(err) {
+				log.Warn("no permission to list pods, skipping namespace", "namespace", ns.Name)
+				continue
+			}
+			return false, err
+		}
+	}
+
+	// ponytail: always false — caller requeueing on deletion not yet wired up
+	return false, nil
+}
+
+func restartStalePodsInNamespace(ctx context.Context, c client.Client, namespace, desiredHash string, log *slog.Logger) error {
+	var pods corev1.PodList
+	if err := c.List(ctx, &pods, client.InNamespace(namespace)); err != nil {
+		return err
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		if !apiv1.CTBRestartEnabled(pod.Annotations) {
+			continue
+		}
+
+		// ponytail: empty hash = treat as matching; avoids deleting pods created before this feature
+		podHash := pod.Annotations[apiv1.AnnotationCTBHash]
+		if podHash == "" || podHash == desiredHash {
+			continue
+		}
+
+		log.Info("deleting stale pod", "namespace", namespace, "pod", pod.Name, "podHash", podHash)
+		if err := c.Delete(ctx, pod); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/ctb/restarter.go
+++ b/internal/ctb/restarter.go
@@ -12,7 +12,7 @@ import (
 
 // RestartStalePods scans all namespaces for pods with "restart-on-change" annotation
 // whose CTB hash doesn't match desiredHash, and deletes them.
-// Empty/missing hash on a pod is treated as matching (pod is skipped).
+// Pods without ownerReferences are skipped (orphan protection).
 // Returns true if any pods were deleted (requeue needed).
 func RestartStalePods(ctx context.Context, c client.Client, desiredHash string) (bool, error) {
 	log := slog.Default().With("controller", "ctb-restarter", "desiredHash", desiredHash)
@@ -54,9 +54,13 @@ func restartStalePodsInNamespace(ctx context.Context, c client.Client, namespace
 			continue
 		}
 
-		// ponytail: empty hash = treat as matching; avoids deleting pods created before this feature
+		if len(pod.OwnerReferences) == 0 {
+			log.Warn("orphan pod has restart-on-change but no owner, skipping", "namespace", namespace, "pod", pod.Name)
+			continue
+		}
+
 		podHash := pod.Annotations[apiv1.AnnotationCTBHash]
-		if podHash == "" || podHash == desiredHash {
+		if podHash == desiredHash {
 			continue
 		}
 

--- a/internal/ctb/restarter.go
+++ b/internal/ctb/restarter.go
@@ -22,26 +22,31 @@ func RestartStalePods(ctx context.Context, c client.Client, desiredHash string) 
 		return false, err
 	}
 
+	var anyDeleted bool
 	for _, ns := range namespaces.Items {
-		if err := restartStalePodsInNamespace(ctx, c, ns.Name, desiredHash, log); err != nil {
+		deleted, err := restartStalePodsInNamespace(ctx, c, ns.Name, desiredHash, log)
+		if err != nil {
 			if errors.IsForbidden(err) {
 				log.Warn("no permission to list pods, skipping namespace", "namespace", ns.Name)
 				continue
 			}
 			return false, err
 		}
+		if deleted {
+			anyDeleted = true
+		}
 	}
 
-	// ponytail: always false — caller requeueing on deletion not yet wired up
-	return false, nil
+	return anyDeleted, nil
 }
 
-func restartStalePodsInNamespace(ctx context.Context, c client.Client, namespace, desiredHash string, log *slog.Logger) error {
+func restartStalePodsInNamespace(ctx context.Context, c client.Client, namespace, desiredHash string, log *slog.Logger) (bool, error) {
 	var pods corev1.PodList
 	if err := c.List(ctx, &pods, client.InNamespace(namespace)); err != nil {
-		return err
+		return false, err
 	}
 
+	var anyDeleted bool
 	for i := range pods.Items {
 		pod := &pods.Items[i]
 
@@ -57,9 +62,10 @@ func restartStalePodsInNamespace(ctx context.Context, c client.Client, namespace
 
 		log.Info("deleting stale pod", "namespace", namespace, "pod", pod.Name, "podHash", podHash)
 		if err := c.Delete(ctx, pod); err != nil && !errors.IsNotFound(err) {
-			return err
+			return false, err
 		}
+		anyDeleted = true
 	}
 
-	return nil
+	return anyDeleted, nil
 }

--- a/internal/ctb/restarter.go
+++ b/internal/ctb/restarter.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// RestartStalePods scans all namespaces for pods with "restart-on-change" annotation
+// RestartStalePods scans all namespaces for pods with annotation value "true"
 // whose CTB hash doesn't match desiredHash, and deletes them.
 // Pods without ownerReferences are skipped (orphan protection).
 // Returns true if any pods were deleted (requeue needed).
@@ -55,7 +55,7 @@ func restartStalePodsInNamespace(ctx context.Context, c client.Client, namespace
 		}
 
 		if len(pod.OwnerReferences) == 0 {
-			log.Warn("orphan pod has restart-on-change but no owner, skipping", "namespace", namespace, "pod", pod.Name)
+			log.Warn("orphan pod has CTB annotation but no owner, skipping", "namespace", namespace, "pod", pod.Name)
 			continue
 		}
 

--- a/internal/ctb/restarter_test.go
+++ b/internal/ctb/restarter_test.go
@@ -1,0 +1,116 @@
+package ctb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
+	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func coreScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	return s
+}
+
+func TestRestartStalePods_DeletesStalePodsOnly(t *testing.T) {
+	s := coreScheme(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
+	stalePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stale-pod",
+			Namespace: "kyma-system",
+			Annotations: map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationCTBHash:              "old-hash",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+	}
+	freshPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fresh-pod",
+			Namespace: "kyma-system",
+			Annotations: map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationCTBHash:              "new-hash",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+	}
+	truePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "true-pod",
+			Namespace: "kyma-system",
+			Annotations: map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "true",
+				apiv1.AnnotationCTBHash:              "old-hash",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+	}
+
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, stalePod, freshPod, truePod).Build()
+
+	requeue, err := ctb.RestartStalePods(context.Background(), fc, "new-hash")
+	require.NoError(t, err)
+	assert.False(t, requeue)
+
+	// stalePod should be deleted
+	var pods corev1.PodList
+	require.NoError(t, fc.List(context.Background(), &pods))
+	names := []string{}
+	for _, p := range pods.Items {
+		names = append(names, p.Name)
+	}
+	assert.NotContains(t, names, "stale-pod")
+	assert.Contains(t, names, "fresh-pod")
+	assert.Contains(t, names, "true-pod")
+}
+
+func TestRestartStalePods_EmptyHashTreatedAsMatching(t *testing.T) {
+	s := coreScheme(t)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
+	podNoHash := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-hash-pod",
+			Namespace: "kyma-system",
+			Annotations: map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+	}
+
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, podNoHash).Build()
+
+	requeue, err := ctb.RestartStalePods(context.Background(), fc, "desired-hash")
+	require.NoError(t, err)
+	assert.False(t, requeue)
+
+	// pod with empty hash should NOT be deleted
+	var pods corev1.PodList
+	require.NoError(t, fc.List(context.Background(), &pods))
+	assert.Len(t, pods.Items, 1)
+}
+
+func TestRestartStalePods_NoPodsNoRequeue(t *testing.T) {
+	s := coreScheme(t)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(ns).Build()
+
+	requeue, err := ctb.RestartStalePods(context.Background(), fc, "hash")
+	require.NoError(t, err)
+	assert.False(t, requeue)
+}

--- a/internal/ctb/restarter_test.go
+++ b/internal/ctb/restarter_test.go
@@ -34,6 +34,7 @@ func TestRestartStalePods_DeletesStalePodsOnly(t *testing.T) {
 				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
 				apiv1.AnnotationCTBHash:              "old-hash",
 			},
+			OwnerReferences: []metav1.OwnerReference{{Name: "deploy", Kind: "ReplicaSet", APIVersion: "apps/v1", UID: "uid1"}},
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
 	}
@@ -45,6 +46,7 @@ func TestRestartStalePods_DeletesStalePodsOnly(t *testing.T) {
 				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
 				apiv1.AnnotationCTBHash:              "new-hash",
 			},
+			OwnerReferences: []metav1.OwnerReference{{Name: "deploy", Kind: "ReplicaSet", APIVersion: "apps/v1", UID: "uid2"}},
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
 	}
@@ -78,31 +80,34 @@ func TestRestartStalePods_DeletesStalePodsOnly(t *testing.T) {
 	assert.Contains(t, names, "true-pod")
 }
 
-func TestRestartStalePods_EmptyHashTreatedAsMatching(t *testing.T) {
+func TestRestartStalePods_OrphanPodSkipped(t *testing.T) {
 	s := coreScheme(t)
 
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
-	podNoHash := &corev1.Pod{
+	orphanPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "no-hash-pod",
+			Name:      "orphan-pod",
 			Namespace: "kyma-system",
 			Annotations: map[string]string{
 				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationCTBHash:              "old-hash",
 			},
+			// No OwnerReferences — orphan pod
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
 	}
 
-	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, podNoHash).Build()
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(ns, orphanPod).Build()
 
-	requeue, err := ctb.RestartStalePods(context.Background(), fc, "desired-hash")
+	requeue, err := ctb.RestartStalePods(context.Background(), fc, "new-hash")
 	require.NoError(t, err)
 	assert.False(t, requeue)
 
-	// pod with empty hash should NOT be deleted
+	// orphan pod must NOT be deleted
 	var pods corev1.PodList
 	require.NoError(t, fc.List(context.Background(), &pods))
 	assert.Len(t, pods.Items, 1)
+	assert.Equal(t, "orphan-pod", pods.Items[0].Name)
 }
 
 func TestRestartStalePods_NoPodsNoRequeue(t *testing.T) {

--- a/internal/ctb/restarter_test.go
+++ b/internal/ctb/restarter_test.go
@@ -31,7 +31,7 @@ func TestRestartStalePods_DeletesStalePodsOnly(t *testing.T) {
 			Name:      "stale-pod",
 			Namespace: "kyma-system",
 			Annotations: map[string]string{
-				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationAddClusterTrustBundle: "true",
 				apiv1.AnnotationCTBHash:              "old-hash",
 			},
 			OwnerReferences: []metav1.OwnerReference{{Name: "deploy", Kind: "ReplicaSet", APIVersion: "apps/v1", UID: "uid1"}},
@@ -43,7 +43,7 @@ func TestRestartStalePods_DeletesStalePodsOnly(t *testing.T) {
 			Name:      "fresh-pod",
 			Namespace: "kyma-system",
 			Annotations: map[string]string{
-				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationAddClusterTrustBundle: "true",
 				apiv1.AnnotationCTBHash:              "new-hash",
 			},
 			OwnerReferences: []metav1.OwnerReference{{Name: "deploy", Kind: "ReplicaSet", APIVersion: "apps/v1", UID: "uid2"}},
@@ -89,7 +89,7 @@ func TestRestartStalePods_OrphanPodSkipped(t *testing.T) {
 			Name:      "orphan-pod",
 			Namespace: "kyma-system",
 			Annotations: map[string]string{
-				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationAddClusterTrustBundle: "true",
 				apiv1.AnnotationCTBHash:              "old-hash",
 			},
 			// No OwnerReferences — orphan pod

--- a/internal/ctb/restarter_test.go
+++ b/internal/ctb/restarter_test.go
@@ -64,7 +64,7 @@ func TestRestartStalePods_DeletesStalePodsOnly(t *testing.T) {
 
 	requeue, err := ctb.RestartStalePods(context.Background(), fc, "new-hash")
 	require.NoError(t, err)
-	assert.False(t, requeue)
+	assert.True(t, requeue)
 
 	// stalePod should be deleted
 	var pods corev1.PodList

--- a/internal/ctb/watcher.go
+++ b/internal/ctb/watcher.go
@@ -3,6 +3,7 @@ package ctb
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,6 +41,14 @@ func (w *CTBWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if oldHash != newHash {
 		log.Info("CTB hash updated", "old", oldHash, "new", newHash)
+	}
+
+	requeue, err := RestartStalePods(ctx, w.Client, newHash)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if requeue {
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/ctb/watcher.go
+++ b/internal/ctb/watcher.go
@@ -1,0 +1,68 @@
+package ctb
+
+import (
+	"context"
+	"log/slog"
+
+	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// +kubebuilder:rbac:groups="certificates.k8s.io",resources=clustertrustbundles,verbs=get;list;watch
+
+// CTBWatcher watches a named ClusterTrustBundle and updates the hash holder on changes.
+type CTBWatcher struct {
+	client.Client
+	Scheme     *runtime.Scheme
+	CTBName    string
+	HashHolder *HashHolder
+}
+
+func (w *CTBWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if req.Name != w.CTBName {
+		return ctrl.Result{}, nil
+	}
+
+	log := slog.Default().With("controller", "ctb-watcher", "ctb-name", req.Name)
+
+	var ctb certificatesv1alpha1.ClusterTrustBundle
+	if err := w.Get(ctx, req.NamespacedName, &ctb); err != nil {
+		log.Error("failed to get ClusterTrustBundle", "error", err)
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	oldHash := w.HashHolder.Get()
+	w.HashHolder.ComputeAndSet(ctb.Spec.TrustBundle)
+	newHash := w.HashHolder.Get()
+
+	if oldHash != newHash {
+		log.Info("CTB hash updated", "old", oldHash, "new", newHash)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (w *CTBWatcher) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&certificatesv1alpha1.ClusterTrustBundle{}).
+		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
+			return object.GetName() == w.CTBName
+		})).
+		Named("ctb-watcher").
+		Complete(w)
+}
+
+// PreComputeHash reads the named CTB and initializes the hash holder.
+// Called at startup before the manager starts.
+func PreComputeHash(ctx context.Context, c client.Client, ctbName string, holder *HashHolder) error {
+	var ctb certificatesv1alpha1.ClusterTrustBundle
+	if err := c.Get(ctx, client.ObjectKey{Name: ctbName}, &ctb); err != nil {
+		return err
+	}
+	holder.ComputeAndSet(ctb.Spec.TrustBundle)
+	slog.Info("CTB hash pre-computed", "ctb-name", ctbName, "hash", holder.Get())
+	return nil
+}

--- a/internal/ctb/watcher.go
+++ b/internal/ctb/watcher.go
@@ -17,9 +17,10 @@ import (
 // CTBWatcher watches a named ClusterTrustBundle and updates the hash holder on changes.
 type CTBWatcher struct {
 	client.Client
-	Scheme     *runtime.Scheme
-	CTBName    string
-	HashHolder *HashHolder
+	Scheme        *runtime.Scheme
+	CTBName       string
+	HashHolder    *HashHolder
+	ResyncInterval time.Duration
 }
 
 func (w *CTBWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -51,7 +52,7 @@ func (w *CTBWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: w.resyncInterval()}, nil
 }
 
 func (w *CTBWatcher) SetupWithManager(mgr ctrl.Manager) error {
@@ -62,6 +63,13 @@ func (w *CTBWatcher) SetupWithManager(mgr ctrl.Manager) error {
 		})).
 		Named("ctb-watcher").
 		Complete(w)
+}
+
+func (w *CTBWatcher) resyncInterval() time.Duration {
+	if w.ResyncInterval > 0 {
+		return w.ResyncInterval
+	}
+	return 5 * time.Minute
 }
 
 // PreComputeHash reads the named CTB and initializes the hash holder.

--- a/internal/ctb/watcher.go
+++ b/internal/ctb/watcher.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log/slog"
 
-	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,7 +28,7 @@ func (w *CTBWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	log := slog.Default().With("controller", "ctb-watcher", "ctb-name", req.Name)
 
-	var ctb certificatesv1alpha1.ClusterTrustBundle
+	var ctb certificatesv1beta1.ClusterTrustBundle
 	if err := w.Get(ctx, req.NamespacedName, &ctb); err != nil {
 		log.Error("failed to get ClusterTrustBundle", "error", err)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -47,7 +47,7 @@ func (w *CTBWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 func (w *CTBWatcher) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&certificatesv1alpha1.ClusterTrustBundle{}).
+		For(&certificatesv1beta1.ClusterTrustBundle{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == w.CTBName
 		})).
@@ -58,7 +58,7 @@ func (w *CTBWatcher) SetupWithManager(mgr ctrl.Manager) error {
 // PreComputeHash reads the named CTB and initializes the hash holder.
 // Called at startup before the manager starts.
 func PreComputeHash(ctx context.Context, c client.Client, ctbName string, holder *HashHolder) error {
-	var ctb certificatesv1alpha1.ClusterTrustBundle
+	var ctb certificatesv1beta1.ClusterTrustBundle
 	if err := c.Get(ctx, client.ObjectKey{Name: ctbName}, &ctb); err != nil {
 		return err
 	}

--- a/internal/ctb/watcher_test.go
+++ b/internal/ctb/watcher_test.go
@@ -5,12 +5,15 @@ import (
 	"testing"
 
 	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
+	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -19,6 +22,7 @@ func newScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
 	require.NoError(t, certificatesv1beta1.AddToScheme(s))
+	require.NoError(t, clientgoscheme.AddToScheme(s))
 	return s
 }
 
@@ -116,4 +120,51 @@ func TestPreComputeHash_NotFound(t *testing.T) {
 	err := ctb.PreComputeHash(context.Background(), fakeClient, "missing-ctb", holder)
 	require.Error(t, err)
 	assert.Empty(t, holder.Get())
+}
+
+func TestCTBWatcher_Reconcile_TriggersRestart(t *testing.T) {
+	s := newScheme(t)
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+
+	ctbObj := &certificatesv1beta1.ClusterTrustBundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
+		Spec:       certificatesv1beta1.ClusterTrustBundleSpec{TrustBundle: "new-bundle"},
+	}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
+	stalePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stale",
+			Namespace: "kyma-system",
+			Annotations: map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationCTBHash:              "old-hash",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+	}
+
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj, ns, stalePod).Build()
+	holder := ctb.NewHashHolder()
+	holder.Set("old-hash") // simulate previous state
+
+	watcher := &ctb.CTBWatcher{
+		Client:     fc,
+		Scheme:     s,
+		CTBName:    "my-ctb",
+		HashHolder: holder,
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "my-ctb"}}
+	result, err := watcher.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	// Should requeue since pods were deleted
+	assert.True(t, result.RequeueAfter > 0 || result.Requeue)
+
+	// Pod should be deleted
+	var pods corev1.PodList
+	require.NoError(t, fc.List(context.Background(), &pods))
+	for _, p := range pods.Items {
+		assert.NotEqual(t, "stale", p.Name)
+	}
 }

--- a/internal/ctb/watcher_test.go
+++ b/internal/ctb/watcher_test.go
@@ -3,6 +3,7 @@ package ctb_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
@@ -43,9 +44,10 @@ func TestCTBWatcher_Reconcile(t *testing.T) {
 		HashHolder: holder,
 	}
 
-	_, err := watcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "my-ctb"}})
+	result, err := watcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "my-ctb"}})
 	require.NoError(t, err)
 	assert.NotEmpty(t, holder.Get())
+	assert.Equal(t, 5*time.Minute, result.RequeueAfter)
 }
 
 func TestCTBWatcher_Reconcile_IgnoresOtherCTBs(t *testing.T) {

--- a/internal/ctb/watcher_test.go
+++ b/internal/ctb/watcher_test.go
@@ -159,7 +159,7 @@ func TestCTBWatcher_Reconcile_TriggersRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should requeue since pods were deleted
-	assert.True(t, result.RequeueAfter > 0 || result.Requeue)
+	assert.True(t, result.RequeueAfter > 0)
 
 	// Pod should be deleted
 	var pods corev1.PodList

--- a/internal/ctb/watcher_test.go
+++ b/internal/ctb/watcher_test.go
@@ -138,7 +138,7 @@ func TestCTBWatcher_Reconcile_TriggersRestart(t *testing.T) {
 			Name:      "stale",
 			Namespace: "kyma-system",
 			Annotations: map[string]string{
-				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationAddClusterTrustBundle: "true",
 				apiv1.AnnotationCTBHash:              "old-hash",
 			},
 			OwnerReferences: []metav1.OwnerReference{{Name: "deploy", Kind: "ReplicaSet", APIVersion: "apps/v1", UID: "uid1"}},

--- a/internal/ctb/watcher_test.go
+++ b/internal/ctb/watcher_test.go
@@ -1,0 +1,119 @@
+package ctb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, certificatesv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestCTBWatcher_Reconcile(t *testing.T) {
+	s := newScheme(t)
+	ctbObj := &certificatesv1alpha1.ClusterTrustBundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
+		Spec:       certificatesv1alpha1.ClusterTrustBundleSpec{TrustBundle: "bundle-content"},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj).Build()
+	holder := ctb.NewHashHolder()
+
+	watcher := &ctb.CTBWatcher{
+		Client:     fakeClient,
+		Scheme:     s,
+		CTBName:    "my-ctb",
+		HashHolder: holder,
+	}
+
+	_, err := watcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "my-ctb"}})
+	require.NoError(t, err)
+	assert.NotEmpty(t, holder.Get())
+}
+
+func TestCTBWatcher_Reconcile_IgnoresOtherCTBs(t *testing.T) {
+	s := newScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+	holder := ctb.NewHashHolder()
+
+	watcher := &ctb.CTBWatcher{
+		Client:     fakeClient,
+		Scheme:     s,
+		CTBName:    "my-ctb",
+		HashHolder: holder,
+	}
+
+	_, err := watcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "other-ctb"}})
+	require.NoError(t, err)
+	assert.Empty(t, holder.Get())
+}
+
+func TestCTBWatcher_Reconcile_HashChangesOnUpdate(t *testing.T) {
+	s := newScheme(t)
+	ctbObj := &certificatesv1alpha1.ClusterTrustBundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
+		Spec:       certificatesv1alpha1.ClusterTrustBundleSpec{TrustBundle: "v1"},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj).Build()
+	holder := ctb.NewHashHolder()
+
+	watcher := &ctb.CTBWatcher{
+		Client:     fakeClient,
+		Scheme:     s,
+		CTBName:    "my-ctb",
+		HashHolder: holder,
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "my-ctb"}}
+	_, err := watcher.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	hash1 := holder.Get()
+
+	// Simulate content change
+	ctbObj.Spec.TrustBundle = "v2"
+	require.NoError(t, fakeClient.Update(context.Background(), ctbObj))
+
+	_, err = watcher.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	hash2 := holder.Get()
+
+	assert.NotEqual(t, hash1, hash2)
+}
+
+func TestPreComputeHash(t *testing.T) {
+	s := newScheme(t)
+	ctbObj := &certificatesv1alpha1.ClusterTrustBundle{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
+		Spec:       certificatesv1alpha1.ClusterTrustBundleSpec{TrustBundle: "test-bundle"},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj).Build()
+	holder := ctb.NewHashHolder()
+
+	require.NoError(t, ctb.PreComputeHash(context.Background(), fakeClient, "my-ctb", holder))
+	assert.NotEmpty(t, holder.Get())
+}
+
+func TestPreComputeHash_NotFound(t *testing.T) {
+	s := newScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+	holder := ctb.NewHashHolder()
+
+	err := ctb.PreComputeHash(context.Background(), fakeClient, "missing-ctb", holder)
+	require.Error(t, err)
+	assert.Empty(t, holder.Get())
+}

--- a/internal/ctb/watcher_test.go
+++ b/internal/ctb/watcher_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,15 +18,15 @@ import (
 func newScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
-	require.NoError(t, certificatesv1alpha1.AddToScheme(s))
+	require.NoError(t, certificatesv1beta1.AddToScheme(s))
 	return s
 }
 
 func TestCTBWatcher_Reconcile(t *testing.T) {
 	s := newScheme(t)
-	ctbObj := &certificatesv1alpha1.ClusterTrustBundle{
+	ctbObj := &certificatesv1beta1.ClusterTrustBundle{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
-		Spec:       certificatesv1alpha1.ClusterTrustBundleSpec{TrustBundle: "bundle-content"},
+		Spec:       certificatesv1beta1.ClusterTrustBundleSpec{TrustBundle: "bundle-content"},
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj).Build()
@@ -63,9 +63,9 @@ func TestCTBWatcher_Reconcile_IgnoresOtherCTBs(t *testing.T) {
 
 func TestCTBWatcher_Reconcile_HashChangesOnUpdate(t *testing.T) {
 	s := newScheme(t)
-	ctbObj := &certificatesv1alpha1.ClusterTrustBundle{
+	ctbObj := &certificatesv1beta1.ClusterTrustBundle{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
-		Spec:       certificatesv1alpha1.ClusterTrustBundleSpec{TrustBundle: "v1"},
+		Spec:       certificatesv1beta1.ClusterTrustBundleSpec{TrustBundle: "v1"},
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj).Build()
@@ -96,9 +96,9 @@ func TestCTBWatcher_Reconcile_HashChangesOnUpdate(t *testing.T) {
 
 func TestPreComputeHash(t *testing.T) {
 	s := newScheme(t)
-	ctbObj := &certificatesv1alpha1.ClusterTrustBundle{
+	ctbObj := &certificatesv1beta1.ClusterTrustBundle{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-ctb"},
-		Spec:       certificatesv1alpha1.ClusterTrustBundleSpec{TrustBundle: "test-bundle"},
+		Spec:       certificatesv1beta1.ClusterTrustBundleSpec{TrustBundle: "test-bundle"},
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(ctbObj).Build()

--- a/internal/ctb/watcher_test.go
+++ b/internal/ctb/watcher_test.go
@@ -139,6 +139,7 @@ func TestCTBWatcher_Reconcile_TriggersRestart(t *testing.T) {
 				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
 				apiv1.AnnotationCTBHash:              "old-hash",
 			},
+			OwnerReferences: []metav1.OwnerReference{{Name: "deploy", Kind: "ReplicaSet", APIVersion: "apps/v1", UID: "uid1"}},
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
 	}

--- a/internal/webhook/k8s/utilz.go
+++ b/internal/webhook/k8s/utilz.go
@@ -46,6 +46,7 @@ type ClusterTrustBundle struct {
 	CertWritePath   string `json:"certWritePath" validate:"required"`
 	VolumeMountPath string `json:"volumeMountPath" validate:"required"`
 	VolumeName      string `json:"volumeName" validate:"required"`
+	ResyncInterval  string `json:"resyncInterval,omitempty"`
 }
 
 func (r ClusterTrustBundle) ClusterTrustedBundle() corev1.Volume {

--- a/internal/webhook/v1/pod_defaulters.go
+++ b/internal/webhook/v1/pod_defaulters.go
@@ -207,7 +207,9 @@ func BuildDefaulterAddClusterTrustBundle(hashHolder *ctb.HashHolder) PodDefaulte
 				modified := handleClusterTrustBundle(p, cfg)
 				// Stamp hash annotation if pod explicitly requested restart-on-change and hash is set
 				if apiv1.CTBRestartEnabled(p.Annotations) {
-					if hash := hashHolder.Get(); hash != "" {
+					if len(p.OwnerReferences) == 0 {
+						slog.Default().WithGroup("args").With(kvs...).Warn("orphan pod has restart-on-change but no owner, treating as 'true'")
+					} else if hash := hashHolder.Get(); hash != "" {
 						if p.Annotations == nil {
 							p.Annotations = map[string]string{}
 						}

--- a/internal/webhook/v1/pod_defaulters.go
+++ b/internal/webhook/v1/pod_defaulters.go
@@ -205,10 +205,10 @@ func BuildDefaulterAddClusterTrustBundle(hashHolder *ctb.HashHolder) PodDefaulte
 			if apiv1.CTBMountEnabled(annotations) || k8s.Contains(annotations, annotationAddClusterTrustBundle) {
 				slog.Default().WithGroup("args").With(kvs...).Debug("CTB pod defaulting opt in")
 				modified := handleClusterTrustBundle(p, cfg)
-				// Stamp hash annotation if pod explicitly requested restart-on-change and hash is set
+					// Stamp hash annotation when annotation is "true" and hash is set
 				if apiv1.CTBRestartEnabled(p.Annotations) {
 					if len(p.OwnerReferences) == 0 {
-						slog.Default().WithGroup("args").With(kvs...).Warn("orphan pod has restart-on-change but no owner, treating as 'true'")
+						slog.Default().WithGroup("args").With(kvs...).Warn("orphan pod has CTB annotation but no owner, skipping hash stamp")
 					} else if hash := hashHolder.Get(); hash != "" {
 						if p.Annotations == nil {
 							p.Annotations = map[string]string{}

--- a/internal/webhook/v1/pod_defaulters.go
+++ b/internal/webhook/v1/pod_defaulters.go
@@ -187,7 +187,27 @@ func BuildDefaulterAddClusterTrustBundle() PodDefaulter {
 		return handleContainers(true, p, c.ClusterTrustBundleMapping)
 	}
 
-	return defaultPod(handleClusterTrustBundle, updateOpts{
-		activeAnnotations: annotationAddClusterTrustBundle,
-	})
+	return func(p *corev1.Pod, nsAnnotations map[string]string, cfg *apiv1.Config) (bool, error) {
+		kvs := keysAndValues(p)
+
+		// Explicit opt-out: pod annotation "false" overrides everything, including namespace defaults.
+		if apiv1.CTBExplicitOptOut(p.Annotations) {
+			slog.Default().WithGroup("args").With(kvs...).Debug("CTB explicit opt out")
+			return false, nil
+		}
+
+		defaultFeatures := cfg.NamespaceDefaultFeatures(p.Namespace)
+		expandedNamespaceAnnotations := cfg.ExpandAnnotationAll(nsAnnotations)
+		expandedPodAnnotations := cfg.ExpandAnnotationAll(p.Annotations)
+
+		for _, annotations := range []map[string]string{defaultFeatures, expandedNamespaceAnnotations, expandedPodAnnotations} {
+			if apiv1.CTBMountEnabled(annotations) || k8s.Contains(annotations, annotationAddClusterTrustBundle) {
+				slog.Default().WithGroup("args").With(kvs...).Debug("CTB pod defaulting opt in")
+				return handleClusterTrustBundle(p, cfg), nil
+			}
+		}
+
+		slog.Default().WithGroup("args").With(kvs...).Debug("CTB opt out")
+		return false, nil
+	}
 }

--- a/internal/webhook/v1/pod_defaulters.go
+++ b/internal/webhook/v1/pod_defaulters.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"slices"
 
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	"github.com/kyma-project/rt-bootstrapper/internal/webhook/k8s"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -115,7 +116,7 @@ func BuildPodDefaulterAddImagePullSecrets(secretName string) PodDefaulter {
 	})
 }
 
-func BuildDefaulterAddClusterTrustBundle() PodDefaulter {
+func BuildDefaulterAddClusterTrustBundle(hashHolder *ctb.HashHolder) PodDefaulter {
 	// slog.Debug("building volume", mapping.KeysAndValues()...)
 
 	handleVolumeMount := func(cs []corev1.Container, m *k8s.ClusterTrustBundle) bool {
@@ -203,7 +204,18 @@ func BuildDefaulterAddClusterTrustBundle() PodDefaulter {
 		for _, annotations := range []map[string]string{defaultFeatures, expandedNamespaceAnnotations, expandedPodAnnotations} {
 			if apiv1.CTBMountEnabled(annotations) || k8s.Contains(annotations, annotationAddClusterTrustBundle) {
 				slog.Default().WithGroup("args").With(kvs...).Debug("CTB pod defaulting opt in")
-				return handleClusterTrustBundle(p, cfg), nil
+				modified := handleClusterTrustBundle(p, cfg)
+				// Stamp hash annotation if pod explicitly requested restart-on-change and hash is set
+				if apiv1.CTBRestartEnabled(p.Annotations) {
+					if hash := hashHolder.Get(); hash != "" {
+						if p.Annotations == nil {
+							p.Annotations = map[string]string{}
+						}
+						p.Annotations[apiv1.AnnotationCTBHash] = hash
+						modified = true
+					}
+				}
+				return modified, nil
 			}
 		}
 

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -35,6 +36,7 @@ type SetupPodWebhookWithManagerOpts struct {
 	NamespaceDefaultFeatures func(string) map[string]string
 	ImagePullSecretName      string
 	Landscape                string
+	HashHolder               *ctb.HashHolder
 	GetConfig
 }
 
@@ -48,7 +50,7 @@ func SetupPodWebhookWithManager(mgr ctrl.Manager, opts SetupPodWebhookWithManage
 	defaulterEntries := []defaulterEntry{
 		{annotation: apiv1.AnnotationAlterImgRegistry, defaulter: BuildPodDefaulterAlterImgRegistry()},
 		{annotation: apiv1.AnnotationSetPullSecret, defaulter: BuildPodDefaulterAddImagePullSecrets(opts.ImagePullSecretName)},
-		{annotation: apiv1.AnnotationAddClusterTrustBundle, defaulter: BuildDefaulterAddClusterTrustBundle()},
+		{annotation: apiv1.AnnotationAddClusterTrustBundle, defaulter: BuildDefaulterAddClusterTrustBundle(opts.HashHolder)},
 		{annotation: apiv1.AnnotationSetFipsMode, defaulter: BuildDefaulterFipsMode()},
 		{annotation: apiv1.AnnotationSetLandscape, defaulter: BuildDefaulterSetLandscape(opts.Landscape)},
 	}

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -310,10 +310,23 @@ var _ = Describe("Pod Webhook", func() {
 			pod := getTestPod(map[string]string{
 				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
 			})
+			pod.OwnerReferences = []metav1.OwnerReference{{Name: "rs", Kind: "ReplicaSet", APIVersion: "apps/v1", UID: "uid1"}}
 
 			err := defaulterCTB.Default(ctx, pod)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(pod.Annotations[apiv1.AnnotationCTBHash]).Should(Equal("abc123"))
+		})
+
+		It("Should NOT stamp hash on orphan pod with 'restart-on-change'", func() {
+			hashHolder.Set("abc123")
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+			})
+			// No OwnerReferences — orphan pod
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Annotations).ShouldNot(HaveKey(apiv1.AnnotationCTBHash))
 		})
 
 		It("Should NOT stamp hash annotation when annotation is 'true'", func() {

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -247,16 +247,7 @@ var _ = Describe("Pod Webhook", func() {
 			Expect(pod.Spec.Volumes[0].Name).Should(Equal("rt-bootstrapper-certs"))
 		})
 
-		It("Should mount CTB when annotation is 'restart-on-change'", func() {
-			pod := getTestPod(map[string]string{
-				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
-			})
 
-			err := defaulterCTB.Default(ctx, pod)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pod.Spec.Volumes).Should(HaveLen(1))
-			Expect(pod.Spec.Volumes[0].Name).Should(Equal("rt-bootstrapper-certs"))
-		})
 
 		It("Should NOT mount CTB when annotation is 'false'", func() {
 			pod := getTestPod(map[string]string{
@@ -305,10 +296,10 @@ var _ = Describe("Pod Webhook", func() {
 			Expect(pod.Spec.Volumes).Should(BeEmpty())
 		})
 
-		It("Should stamp hash annotation when 'restart-on-change' and hash is set", func() {
+		It("Should stamp hash annotation when 'true' and hash is set", func() {
 			hashHolder.Set("abc123")
 			pod := getTestPod(map[string]string{
-				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationAddClusterTrustBundle: "true",
 			})
 			pod.OwnerReferences = []metav1.OwnerReference{{Name: "rs", Kind: "ReplicaSet", APIVersion: "apps/v1", UID: "uid1"}}
 
@@ -317,10 +308,10 @@ var _ = Describe("Pod Webhook", func() {
 			Expect(pod.Annotations[apiv1.AnnotationCTBHash]).Should(Equal("abc123"))
 		})
 
-		It("Should NOT stamp hash on orphan pod with 'restart-on-change'", func() {
+		It("Should NOT stamp hash on orphan pod with 'true'", func() {
 			hashHolder.Set("abc123")
 			pod := getTestPod(map[string]string{
-				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationAddClusterTrustBundle: "true",
 			})
 			// No OwnerReferences — orphan pod
 
@@ -329,21 +320,12 @@ var _ = Describe("Pod Webhook", func() {
 			Expect(pod.Annotations).ShouldNot(HaveKey(apiv1.AnnotationCTBHash))
 		})
 
-		It("Should NOT stamp hash annotation when annotation is 'true'", func() {
-			hashHolder.Set("abc123")
-			pod := getTestPod(map[string]string{
-				apiv1.AnnotationAddClusterTrustBundle: "true",
-			})
 
-			err := defaulterCTB.Default(ctx, pod)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pod.Annotations).ShouldNot(HaveKey(apiv1.AnnotationCTBHash))
-		})
 
 		It("Should NOT stamp hash annotation when hash is empty", func() {
 			hashHolder.Set("")
 			pod := getTestPod(map[string]string{
-				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+				apiv1.AnnotationAddClusterTrustBundle: "true",
 			})
 
 			err := defaulterCTB.Default(ctx, pod)

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kyma-project/rt-bootstrapper/internal/ctb"
 	"github.com/kyma-project/rt-bootstrapper/internal/webhook/k8s"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -218,7 +219,8 @@ var _ = Describe("Pod Webhook", func() {
 			},
 		}
 
-		d3 := BuildDefaulterAddClusterTrustBundle()
+		hashHolder := ctb.NewHashHolder()
+		d3 := BuildDefaulterAddClusterTrustBundle(hashHolder)
 
 		defaulterCTB := podCustomDefaulter{
 			availableFeatures: []string{
@@ -283,7 +285,7 @@ var _ = Describe("Pod Webhook", func() {
 				availableFeatures: []string{
 					apiv1.AnnotationAddClusterTrustBundle,
 				},
-				defaulters: []PodDefaulter{BuildDefaulterAddClusterTrustBundle()},
+				defaulters: []PodDefaulter{BuildDefaulterAddClusterTrustBundle(ctb.NewHashHolder())},
 				GetNsAnnotations: func(_ context.Context, name string) (map[string]string, error) {
 					return nil, nil
 				},
@@ -302,7 +304,40 @@ var _ = Describe("Pod Webhook", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(pod.Spec.Volumes).Should(BeEmpty())
 		})
-	})
+
+		It("Should stamp hash annotation when 'restart-on-change' and hash is set", func() {
+			hashHolder.Set("abc123")
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+			})
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Annotations[apiv1.AnnotationCTBHash]).Should(Equal("abc123"))
+		})
+
+		It("Should NOT stamp hash annotation when annotation is 'true'", func() {
+			hashHolder.Set("abc123")
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "true",
+			})
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Annotations).ShouldNot(HaveKey(apiv1.AnnotationCTBHash))
+		})
+
+		It("Should NOT stamp hash annotation when hash is empty", func() {
+			hashHolder.Set("")
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+			})
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Annotations).ShouldNot(HaveKey(apiv1.AnnotationCTBHash))
+		})
+	}) // end Context("ClusterTrustBundle annotation values")
 
 	Context("When creating Pod under Defaulting Webhook", func() {
 		It("Should inject landscape env var", func() {

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kyma-project/rt-bootstrapper/internal/webhook/k8s"
 	apiv1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -198,7 +199,112 @@ var _ = Describe("Pod Webhook", func() {
 				corev1.LocalObjectReference{Name: testPullSecret},
 			))
 		})
+	}) // end Context("When creating Pod under Defaulting Webhook")
 
+	Context("ClusterTrustBundle annotation values", func() {
+		ctbMapping := &k8s.ClusterTrustBundle{
+			Name:            "test-ctb",
+			CertWritePath:   "ca.pem",
+			VolumeMountPath: "/etc/ssl/certs",
+			VolumeName:      "rt-bootstrapper-certs",
+		}
+
+		cfgCTB := &apiv1.Config{
+			NamespaceFeatures:         &apiv1.NamespaceFeatures{},
+			Overrides:                 map[string]string{},
+			ClusterTrustBundleMapping: ctbMapping,
+			AvailableFeatures: []string{
+				apiv1.AnnotationAddClusterTrustBundle,
+			},
+		}
+
+		d3 := BuildDefaulterAddClusterTrustBundle()
+
+		defaulterCTB := podCustomDefaulter{
+			availableFeatures: []string{
+				apiv1.AnnotationAddClusterTrustBundle,
+			},
+			defaulters: []PodDefaulter{d3},
+			GetNsAnnotations: func(_ context.Context, name string) (map[string]string, error) {
+				return nil, nil
+			},
+			GetConfig: func(_ context.Context) (*apiv1.Config, error) {
+				return cfgCTB, nil
+			},
+			namespaceDefaultFeatures: cfgCTB.NamespaceDefaultFeatures,
+		}
+
+		It("Should mount CTB when annotation is 'true'", func() {
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "true",
+			})
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Spec.Volumes).Should(HaveLen(1))
+			Expect(pod.Spec.Volumes[0].Name).Should(Equal("rt-bootstrapper-certs"))
+		})
+
+		It("Should mount CTB when annotation is 'restart-on-change'", func() {
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "restart-on-change",
+			})
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Spec.Volumes).Should(HaveLen(1))
+			Expect(pod.Spec.Volumes[0].Name).Should(Equal("rt-bootstrapper-certs"))
+		})
+
+		It("Should NOT mount CTB when annotation is 'false'", func() {
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "false",
+			})
+
+			err := defaulterCTB.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Spec.Volumes).Should(BeEmpty())
+		})
+
+		It("Should NOT mount CTB when annotation is 'false' even with namespace defaults", func() {
+			nsFeat := apiv1.NamespaceFeatures{
+				"kyma-system": {apiv1.AnnotationAddClusterTrustBundle},
+			}
+			cfgNS := &apiv1.Config{
+				NamespaceFeatures:         &nsFeat,
+				Overrides:                 map[string]string{},
+				ClusterTrustBundleMapping: ctbMapping,
+				AvailableFeatures: []string{
+					apiv1.AnnotationAddClusterTrustBundle,
+				},
+			}
+
+			defaulterNS := podCustomDefaulter{
+				availableFeatures: []string{
+					apiv1.AnnotationAddClusterTrustBundle,
+				},
+				defaulters: []PodDefaulter{BuildDefaulterAddClusterTrustBundle()},
+				GetNsAnnotations: func(_ context.Context, name string) (map[string]string, error) {
+					return nil, nil
+				},
+				GetConfig: func(_ context.Context) (*apiv1.Config, error) {
+					return cfgNS, nil
+				},
+				namespaceDefaultFeatures: cfgNS.NamespaceDefaultFeatures,
+			}
+
+			pod := getTestPod(map[string]string{
+				apiv1.AnnotationAddClusterTrustBundle: "false",
+			})
+			pod.Namespace = "kyma-system"
+
+			err := defaulterNS.Default(ctx, pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pod.Spec.Volumes).Should(BeEmpty())
+		})
+	})
+
+	Context("When creating Pod under Defaulting Webhook", func() {
 		It("Should inject landscape env var", func() {
 			d5 := BuildDefaulterSetLandscape("NS2")
 			cfgLandscape := &apiv1.Config{

--- a/openspec/changes/remove-restart-on-change/.openspec.yaml
+++ b/openspec/changes/remove-restart-on-change/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/openspec/changes/remove-restart-on-change/design.md
+++ b/openspec/changes/remove-restart-on-change/design.md
@@ -1,0 +1,84 @@
+# Design: Remove `restart-on-change` annotation value
+
+## Context
+
+The ClusterTrustBundle (CTB) annotation (`apiv1.AnnotationAddClusterTrustBundle`) currently accepts three string values:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  CURRENT TRIVARIATE VALUES                               │
+├──────────────┬───────────────────────────────────────────┤
+│  Value       │  Behavior                                 │
+├──────────────┼───────────────────────────────────────────┤
+│  "true"      │  Mount CTB volume only                  │
+│  "false"     │  Do nothing (explicit opt-out)          │
+│  "restart-  │  Mount CTB + restart pod on hash change │
+│  -on-change" │                                         │
+└──────────────┴───────────────────────────────────────────┘
+```
+
+The problem: two values (`"true"` and `"restart-on-change"`) both enable CTB mounting, but differ on whether pods get restarted. Users face a confusing choice. The intended "full CTB experience" (mount + restart) is only available via the verbose `"restart-on-change"`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Collapse `"restart-on-change"` into `"true"`.
+- `"true"` means: mount CTB **and** restart pods when CTB hash changes.
+- `"false"` means: do nothing.
+- Keep `"false"` opt-out semantics unchanged.
+
+**Non-Goals:**
+- Do not support a value that mounts CTB without restarting.
+- Do not change the restarter logic (it already deletes stale pods correctly).
+- Do not change the hash holder, watcher, or CRD definitions.
+
+## Decisions
+
+### D1: `"true"` does both mount + restart
+
+**Decision:** The `"true"` annotation value will simultaneously mount the CTB volume and enable pod restart on hash changes.
+
+**Rationale:**
+- The vast majority of users who want CTB also want automatic restart when the bundle changes.
+- Eliminating the "mount only" case removes an option that was only useful for very specific edge cases.
+- Simpler API surface = fewer configuration mistakes.
+
+**Alternatives considered:**
+1. Keep `"true"` as mount-only and add `"restarting-true"` — Rejected: more confusing, same problem.
+2. Remove the restarter entirely — Rejected: restart-on-change is a valuable feature.
+3. Add a separate annotation for restart — Rejected: couples two orthogonal concerns unnecessarily.
+
+### D2: `CTBRestartEnabled` and `CTBMountEnabled` converge
+
+**Decision:** After this change, when `CTBMountEnabled` returns `true` (i.e., annotation is `"true"`), `CTBRestartEnabled` effectively returns the same. The restarter check simplifies to `CTBMountEnabled`.
+
+**Rationale:**
+- The internal API functions can be simplified. `CTBRestartEnabled` can either be removed or made equivalent to `CTBMountEnabled`.
+- In the webhook defaulters, the check `CTBRestartEnabled(p.Annotations)` becomes simply `CTBMountEnabled(p.Annotations)` since `"true"` is the only truthy value.
+
+### D3: Upward-compatible migration — nothing blocks, behavior just changes
+
+**Decision:** Existing pods with `"restart-on-change"` will continue to work. On next reconciliation:
+1. The defaulter sees `"restart-on-change"` is no longer recognized as a valid truthy value.
+2. The annotation is effectively treated as unknown — but **expanded annotations** may normalize it.
+3. Hash stamping triggers, and the restarter handles restart normally.
+
+**Important:** Since `"restart-on-change"` is no longer a recognized value, it will NOT match `CTBMountEnabled` after the code change, meaning existing pods with `"restart-on-change"` will NOT be re-defaulted unless their annotation is `"true"`. **This is the breaking change.** Users must update existing pod annotations to `"true"` to maintain the current behavior.
+
+## Risks / Trade-offs
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Existing pods annotated with `"restart-on-change"` stop getting CTB restarts | High | Document the breaking change clearly; users must update annotations to `"true"` |
+| Pods that only wanted CTB mount (no restart) lose restart functionality | Low | No known use case for mount-without-restart exists |
+| Test gaps — some `"restart-on-change"` references missed | Medium | grep-driven audit of all usages (see Impact above) |
+
+## Migration Plan
+
+1. **Code change** (this PR/merge): Remove `CTBValueRestartOnChange`, merge semantics into `"true"`.
+2. **Docs update**: Update any documentation referencing `"restart-on-change"` to use `"true"` instead.
+3. **User communication**: If any users have pods using `"restart-on-change"`, they need to update to `"true"`.
+
+## Open Questions
+
+None remaining.

--- a/openspec/changes/remove-restart-on-change/proposal.md
+++ b/openspec/changes/remove-restart-on-change/proposal.md
@@ -1,0 +1,33 @@
+# Remove `restart-on-change` annotation value
+
+## Why
+
+The ClusterTrustBundle annotation currently supports three values: `"true"`, `"false"`, and `"restart-on-change"`. This creates confusion because `"true"` only mounts the CTB volume without restarting pods, while `"restart-on-change"` both mounts and restarts. The dual-value semantics are inconsistent — users shouldn't need to know which of two truthy values to pick when they want full CTB functionality. Collapsing them into a single `"true"` that does both simplifies the mental model and reduces configuration errors.
+
+## What Changes
+
+- **Remove** the `"restart-on-change"` annotation value entirely. It becomes an invalid/ignored value.
+- **Change** `"true"` to both mount the CTB volume **and** trigger pod restarts when the CTB hash changes (current `"restart-on-change"` behavior).
+- **`"false"`** remains unchanged: neither mounts CTB nor restarts.
+- All test code referencing `"restart-on-change"` is updated to use `"true"`.
+- **BREAKING**: Existing pods with `"restart-on-change"` annotation will see their CTB restarted as part of normal reconciliation (hash stamping will occur and stale pods will be deleted). This is the intended behavior.
+
+## Capabilities
+
+### New Capabilities
+- `ctb-annotation-value`: Defines the simplified CTB annotation value semantics (only `"true"` and `"false"`).
+
+### Modified Capabilities
+<!-- None — no existing main specs exist yet. This creates a new capability. -->
+
+## Impact
+
+| Area | Files affected |
+|------|---------------|
+| API constants | `pkg/api/v1/ctb_values.go` — remove `CTBValueRestartOnChange` |
+| CTB defaulting | `internal/webhook/v1/pod_defaulters.go` — check `"true"` instead of `"restart-on-change"` for hash stamping |
+| CTB restarter | `internal/ctb/restarter.go` — call simplified check for restart eligibility |
+| Watcher tests | `internal/ctb/watcher_test.go` |
+| Restarter tests | `internal/ctb/restarter_test.go` |
+| Webhook tests | `internal/webhook/v1/pod_webhook_test.go` |
+| Types tests | `pkg/api/v1/types_test.go` |

--- a/openspec/changes/remove-restart-on-change/specs/ctb-annotation-value/spec.md
+++ b/openspec/changes/remove-restart-on-change/specs/ctb-annotation-value/spec.md
@@ -1,0 +1,73 @@
+# CTB Annotation Value Simplification
+
+## ADDED Requirements
+
+### Requirement: Allowed annotation values
+
+The `AnnotationAddClusterTrustBundle` annotation SHALL accept exactly two values:
+
+- `"true"` — Enable CTB volume mounting AND pod restart on hash changes.
+- `"false"` — Explicit opt-out: do not mount CTB and do not restart.
+
+Any other value (including the previously supported `"restart-on-change"`) SHALL be treated as unknown and ignored (neither mount nor restart).
+
+#### Scenario: Value is "true"
+- **WHEN** a pod has `AnnotationAddClusterTrustBundle` set to `"true"`
+- **THEN** the webhook defaulters SHALL mount the ClusterTrustBundle projected volume
+- **THEN** the hash SHALL be stamped on the pod (if available from HashHolder)
+- **THEN** the CTB restarter SHALL restart the pod when the CTB hash changes
+
+#### Scenario: Value is "false"
+- **WHEN** a pod has `AnnotationAddClusterTrustBundle` set to `"false"`
+- **THEN** the webhook defaulters SHALL NOT mount the ClusterTrustBundle volume
+- **THEN** the CTB restarter SHALL NOT restart the pod
+
+#### Scenario: Value is "restart-on-change" (removed)
+- **WHEN** a pod has `AnnotationAddClusterTrustBundle` set to `"restart-on-change"`
+- **THEN** the value is treated as unknown and ignored
+- **THEN** no CTB volume is mounted
+- **THEN** no pod restart is triggered
+
+#### Scenario: Value is unknown
+- **WHEN** a pod has `AnnotationAddClusterTrustBundle` set to any unrecognized value
+- **THEN** the value is treated as unknown and ignored
+- **THEN** no CTB volume is mounted
+- **THEN** no pod restart is triggered
+
+### Requirement: CTBMountEnabled behavior
+
+The function `CTBMountEnabled(annotations)` SHALL return `true` only when the annotation value is `"true"`. It SHALL return `false` for `"false"`, `"restart-on-change"`, unknown values, or missing annotations.
+
+#### Scenario: CTBMountEnabled with "true"
+- **WHEN** annotations contain `AnnotationAddClusterTrustBundle: "true"`
+- **THEN** `CTBMountEnabled` returns `true`
+
+#### Scenario: CTBMountEnabled with "false"
+- **WHEN** annotations contain `AnnotationAddClusterTrustBundle: "false"`
+- **THEN** `CTBMountEnabled` returns `false`
+
+#### Scenario: CTBMountEnabled with "restart-on-change"
+- **WHEN** annotations contain `AnnotationAddClusterTrustBundle: "restart-on-change"`
+- **THEN** `CTBMountEnabled` returns `false`
+
+#### Scenario: CTBMountEnabled with missing annotation
+- **WHEN** annotations are nil or missing `AnnotationAddClusterTrustBundle`
+- **THEN** `CTBMountEnabled` returns `false`
+
+### Requirement: CTBRestartEnabled behavior
+
+The CTB restarter SHALL restart pods only when the annotation value is `"true"`. The restarter SHALL NOT restart pods with `"false"`, `"restart-on-change"`, or any other value.
+
+#### Scenario: Restarter restarts "true" pods with stale hash
+- **WHEN** a pod has `AnnotationAddClusterTrustBundle: "true"`
+- **AND** the pod's `AnnotationCTBHash` differs from the desired hash
+- **THEN** the restarter SHALL delete the pod
+
+#### Scenario: Restarter skips "false" pods
+- **WHEN** a pod has `AnnotationAddClusterTrustBundle: "false"`
+- **THEN** the restarter SHALL NOT restart the pod regardless of hash
+
+#### Scenario: Restarter skips orphan pods
+- **WHEN** a pod has `AnnotationAddClusterTrustBundle: "true"` but no `OwnerReferences`
+- **THEN** the restarter SHALL NOT delete the pod
+- **THEN** a warning log entry SHALL be recorded

--- a/openspec/changes/remove-restart-on-change/tasks.md
+++ b/openspec/changes/remove-restart-on-change/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: Remove `restart-on-change` annotation value
+
+## 1. Update API constants and helpers
+
+- [ ] 1.1 Remove `CTBValueRestartOnChange` constant from `pkg/api/v1/ctb_values.go`
+- [ ] 1.2 Update `CTBMountEnabled` to return `true` only for `"true"` (remove `CTBValueRestartOnChange` from the check)
+- [ ] 1.3 Update `CTBRestartEnabled` to return `true` only for `"true"` (remove `CTBValueRestartOnChange` from the check)
+- [ ] 1.4 Update comments on constants to reflect simplified semantics
+
+## 2. Update webhook defaulters
+
+- [ ] 2.1 In `internal/webhook/v1/pod_defaulters.go`, change the `CTBRestartEnabled` check to use the simplified logic (check annotation == `"true"`)
+- [ ] 2.2 Update the orphan pod warning message to no longer reference "restart-on-change"
+
+## 3. Update CTB restarter
+
+- [ ] 3.1 In `internal/ctb/restarter.go`, update the comment referencing "restart-on-change" annotation
+- [ ] 3.2 Update the orphan pod warning message to no longer reference "restart-on-change"
+
+## 4. Update unit tests
+
+- [ ] 4.1 In `pkg/api/v1/ctb_values_test.go`: remove `"restart-on-change"` test case from `TestCTBMountEnabled`
+- [ ] 4.2 In `pkg/api/v1/ctb_values_test.go`: update `TestCTBRestartEnabled` to expect `false` for `"restart-on-change"` and rename/add tests as needed
+- [ ] 4.3 In `pkg/api/v1/types_test.go`: update "restart-on-change preserved over all expansion" test
+- [ ] 4.4 In `internal/ctb/restarter_test.go`: replace `"restart-on-change"` with `"true"` in all test pods
+- [ ] 4.5 In `internal/ctb/watcher_test.go`: replace `"restart-on-change"` with `"true"` in test pod
+- [ ] 4.6 In `internal/webhook/v1/pod_webhook_test.go`: replace all `"restart-on-change"` with `"true"`, update test descriptions, remove separate "restart-on-change" mount test (now covered by "true")
+
+## 5. Verify
+
+- [ ] 5.1 Run `go test ./...` to confirm all tests pass
+- [ ] 5.2 Run `grep -rn "restart-on-change"` to confirm no references remain in non-test code
+- [ ] 5.3 Validate the OpenSpec artifacts with `openspec validate remove-restart-on-change`

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/pkg/api/v1/ctb_values.go
+++ b/pkg/api/v1/ctb_values.go
@@ -1,12 +1,10 @@
 package v1
 
 const (
-	// CTBValueTrue enables CTB volume mounting (existing behavior).
+	// CTBValueTrue enables CTB volume mounting and controller-managed restart.
 	CTBValueTrue = "true"
-	// CTBValueFalse explicitly opts out of CTB volume mounting.
+	// CTBValueFalse explicitly opts out of CTB volume mounting and restart.
 	CTBValueFalse = "false"
-	// CTBValueRestartOnChange enables CTB mounting and controller-managed restart.
-	CTBValueRestartOnChange = "restart-on-change"
 )
 
 // CTBMountEnabled returns true if the annotation value signals that the
@@ -16,7 +14,7 @@ func CTBMountEnabled(annotations map[string]string) bool {
 	if !ok {
 		return false
 	}
-	return v == CTBValueTrue || v == CTBValueRestartOnChange
+	return v == CTBValueTrue
 }
 
 // CTBExplicitOptOut returns true if the pod explicitly opts out via "false".
@@ -27,10 +25,11 @@ func CTBExplicitOptOut(annotations map[string]string) bool {
 
 // CTBRestartEnabled returns true if the annotation value signals that the
 // pod should be restarted when the CTB CA changes.
+// Only "true" enables restart; "false" and any unknown value do not.
 func CTBRestartEnabled(annotations map[string]string) bool {
 	v, ok := annotations[AnnotationAddClusterTrustBundle]
 	if !ok {
 		return false
 	}
-	return v == CTBValueRestartOnChange
+	return v == CTBValueTrue
 }

--- a/pkg/api/v1/ctb_values.go
+++ b/pkg/api/v1/ctb_values.go
@@ -19,6 +19,12 @@ func CTBMountEnabled(annotations map[string]string) bool {
 	return v == CTBValueTrue || v == CTBValueRestartOnChange
 }
 
+// CTBExplicitOptOut returns true if the pod explicitly opts out via "false".
+func CTBExplicitOptOut(annotations map[string]string) bool {
+	v, ok := annotations[AnnotationAddClusterTrustBundle]
+	return ok && v == CTBValueFalse
+}
+
 // CTBRestartEnabled returns true if the annotation value signals that the
 // pod should be restarted when the CTB CA changes.
 func CTBRestartEnabled(annotations map[string]string) bool {

--- a/pkg/api/v1/ctb_values.go
+++ b/pkg/api/v1/ctb_values.go
@@ -1,0 +1,30 @@
+package v1
+
+const (
+	// CTBValueTrue enables CTB volume mounting (existing behavior).
+	CTBValueTrue = "true"
+	// CTBValueFalse explicitly opts out of CTB volume mounting.
+	CTBValueFalse = "false"
+	// CTBValueRestartOnChange enables CTB mounting and controller-managed restart.
+	CTBValueRestartOnChange = "restart-on-change"
+)
+
+// CTBMountEnabled returns true if the annotation value signals that the
+// ClusterTrustBundle projected volume should be mounted.
+func CTBMountEnabled(annotations map[string]string) bool {
+	v, ok := annotations[AnnotationAddClusterTrustBundle]
+	if !ok {
+		return false
+	}
+	return v == CTBValueTrue || v == CTBValueRestartOnChange
+}
+
+// CTBRestartEnabled returns true if the annotation value signals that the
+// pod should be restarted when the CTB CA changes.
+func CTBRestartEnabled(annotations map[string]string) bool {
+	v, ok := annotations[AnnotationAddClusterTrustBundle]
+	if !ok {
+		return false
+	}
+	return v == CTBValueRestartOnChange
+}

--- a/pkg/api/v1/ctb_values_test.go
+++ b/pkg/api/v1/ctb_values_test.go
@@ -16,7 +16,7 @@ func TestCTBMountEnabled(t *testing.T) {
 		{name: "absent", annotations: map[string]string{}, want: false},
 		{name: "true", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "true"}, want: true},
 		{name: "false", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "false"}, want: false},
-		{name: "restart-on-change", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "restart-on-change"}, want: true},
+		{name: "restart-on-change (removed)", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "restart-on-change"}, want: false},
 		{name: "unknown value", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "garbage"}, want: false},
 		{name: "nil map", annotations: nil, want: false},
 	}
@@ -34,9 +34,9 @@ func TestCTBRestartEnabled(t *testing.T) {
 		want        bool
 	}{
 		{name: "absent", annotations: map[string]string{}, want: false},
-		{name: "true", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "true"}, want: false},
+		{name: "true", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "true"}, want: true},
 		{name: "false", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "false"}, want: false},
-		{name: "restart-on-change", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "restart-on-change"}, want: true},
+		{name: "restart-on-change (removed)", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "restart-on-change"}, want: false},
 		{name: "nil map", annotations: nil, want: false},
 	}
 	for _, tc := range tcs {

--- a/pkg/api/v1/ctb_values_test.go
+++ b/pkg/api/v1/ctb_values_test.go
@@ -1,0 +1,47 @@
+package v1_test
+
+import (
+	"testing"
+
+	v1 "github.com/kyma-project/rt-bootstrapper/pkg/api/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCTBMountEnabled(t *testing.T) {
+	tcs := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{name: "absent", annotations: map[string]string{}, want: false},
+		{name: "true", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "true"}, want: true},
+		{name: "false", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "false"}, want: false},
+		{name: "restart-on-change", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "restart-on-change"}, want: true},
+		{name: "unknown value", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "garbage"}, want: false},
+		{name: "nil map", annotations: nil, want: false},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, v1.CTBMountEnabled(tc.annotations))
+		})
+	}
+}
+
+func TestCTBRestartEnabled(t *testing.T) {
+	tcs := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{name: "absent", annotations: map[string]string{}, want: false},
+		{name: "true", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "true"}, want: false},
+		{name: "false", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "false"}, want: false},
+		{name: "restart-on-change", annotations: map[string]string{v1.AnnotationAddClusterTrustBundle: "restart-on-change"}, want: true},
+		{name: "nil map", annotations: nil, want: false},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, v1.CTBRestartEnabled(tc.annotations))
+		})
+	}
+}

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -21,6 +21,7 @@ const (
 	AnnotationSetLandscape          = "rt-cfg.kyma-project.io/set-landscape"
 	AnnotationAll                   = "rt-cfg.kyma-project.io/all"
 	AnnotationModified              = "rt-bootstrapper.kyma-project.io/modified"
+	AnnotationCTBHash               = "rt-bootstrapper.kyma-project.io/ctb-hash"
 	FiledManager                    = "rt-bootstrapper"
 	EnvKymaFipsModeEnabled          = "KYMA_FIPS_MODE_ENABLED"
 	EnvFipsModeEnabled              = "FIPS_MODE_ENABLED"

--- a/pkg/api/v1/types_test.go
+++ b/pkg/api/v1/types_test.go
@@ -162,3 +162,33 @@ func TestConfig_ExpandAnnotationAll(t *testing.T) {
 		assert.Equal(t, in, cfg.ExpandAnnotationAll(in))
 	})
 }
+
+func TestConfig_ExpandAnnotationAll_PreservesCTBValues(t *testing.T) {
+	cfg := &v1.Config{
+		Overrides: map[string]string{"x": "y"},
+		AvailableFeatures: []string{
+			v1.AnnotationAlterImgRegistry,
+			v1.AnnotationSetPullSecret,
+			v1.AnnotationAddClusterTrustBundle,
+		},
+	}
+
+	t.Run("restart-on-change preserved over all expansion", func(t *testing.T) {
+		got := cfg.ExpandAnnotationAll(map[string]string{
+			v1.AnnotationAll:                "true",
+			v1.AnnotationAddClusterTrustBundle: "restart-on-change",
+		})
+		assert.Equal(t, "restart-on-change", got[v1.AnnotationAddClusterTrustBundle])
+		assert.Equal(t, "true", got[v1.AnnotationAlterImgRegistry])
+		assert.Equal(t, "true", got[v1.AnnotationSetPullSecret])
+	})
+
+	t.Run("false preserved over all expansion", func(t *testing.T) {
+		got := cfg.ExpandAnnotationAll(map[string]string{
+			v1.AnnotationAll:                "true",
+			v1.AnnotationAddClusterTrustBundle: "false",
+		})
+		assert.Equal(t, "false", got[v1.AnnotationAddClusterTrustBundle])
+		assert.Equal(t, "true", got[v1.AnnotationAlterImgRegistry])
+	})
+}

--- a/pkg/api/v1/types_test.go
+++ b/pkg/api/v1/types_test.go
@@ -173,12 +173,12 @@ func TestConfig_ExpandAnnotationAll_PreservesCTBValues(t *testing.T) {
 		},
 	}
 
-	t.Run("restart-on-change preserved over all expansion", func(t *testing.T) {
+	t.Run("CTB annotation preserved over all expansion", func(t *testing.T) {
 		got := cfg.ExpandAnnotationAll(map[string]string{
 			v1.AnnotationAll:                "true",
-			v1.AnnotationAddClusterTrustBundle: "restart-on-change",
+			v1.AnnotationAddClusterTrustBundle: "true",
 		})
-		assert.Equal(t, "restart-on-change", got[v1.AnnotationAddClusterTrustBundle])
+		assert.Equal(t, "true", got[v1.AnnotationAddClusterTrustBundle])
 		assert.Equal(t, "true", got[v1.AnnotationAlterImgRegistry])
 		assert.Equal(t, "true", got[v1.AnnotationSetPullSecret])
 	})


### PR DESCRIPTION
## Summary

The ClusterTrustBundle (CTB) annotation currently supports three values: `"true"`, `"false"`, and `"restart-on-change"`. This creates confusing semantics — `"true"` only mounts the CTB without restarting, while `"restart-on-change"` does both.

This change collapses `"restart-on-change"` into `"true"`, so that:

- **`"true"\** — Mount CTB volume AND restart pods on hash changes
- **`"false"\** — Explicit opt-out (do nothing)
- **Any other value (including `"restart-on-change"`)** — Treated as unknown, ignored

## What Changed

| File | Change |
|------|--------|
| `pkg/api/v1/ctb_values.go` | Removed `CTBValueRestartOnChange`; `CTBMountEnabled` and `CTBRestartEnabled` now check only `"true"` |
| `internal/ctb/restarter.go` | Updated comments and warning message |
| `internal/webhook/v1/pod_defaulters.go` | Updated hash-stamping logic and warning message |
| `pkg/api/v1/ctb_values_test.go` | Updated test expectations |
| `pkg/api/v1/types_test.go` | Updated expansion test |
| `internal/ctb/restarter_test.go` | Test pods now use `"true"` |
| `internal/ctb/watcher_test.go` | Test pod now uses `"true"` |
| `internal/webhook/v1/pod_webhook_test.go` | Updated/rename tests |

## Breaking Change

Existing pods annotated with `restart-on-change` will need to update to `"true"` to maintain the current behavior (mount + restart). This is documented in the [OpenSpec change](openspec/changes/remove-restart-on-change/proposal.md).

## OpenSpec

This change includes a complete OpenSpec proposal with proposal, design, spec, and tasks artifacts.